### PR TITLE
Remove redundant [wheel] section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [bdist_wheel]
 universal = 1
-    
-[wheel]
-universal = 1


### PR DESCRIPTION
The [wheel] section is legacy and not required. [bdist_wheel] is enough. For additional details, see:

https://github.com/pypa/wheel/blob/3dc261abc98a5e43bc7fcf5783d080aaf8f9f0cf/wheel/bdist_wheel.py#L127-L133

http://pythonwheels.com/