### PR TITLE
Fix collections ABCs deprecation warning

### DIFF
--- a/pyparsing.py
+++ b/pyparsing.py
@@ -83,6 +83,15 @@ except ImportError:
     from threading import RLock
 
 try:
+    # Python 3
+    from collections.abc import Iterable
+    from collections.abc import MutableMapping
+except ImportError:
+    # Python 2.7
+    from collections import Iterable
+    from collections import MutableMapping
+
+try:
     from collections import OrderedDict as _OrderedDict
 except ImportError:
     try:
@@ -940,7 +949,7 @@ class ParseResults(object):
     def __dir__(self):
         return (dir(type(self)) + list(self.keys()))
 
-collections.MutableMapping.register(ParseResults)
+MutableMapping.register(ParseResults)
 
 def col (loc,strg):
     """Returns current column within a string, counting newlines as line separators.
@@ -3242,7 +3251,7 @@ class ParseExpression(ParserElement):
 
         if isinstance( exprs, basestring ):
             self.exprs = [ ParserElement._literalStringClass( exprs ) ]
-        elif isinstance( exprs, collections.Iterable ):
+        elif isinstance( exprs, Iterable ):
             exprs = list(exprs)
             # if sequence of strings provided, wrap with Literal
             if all(isinstance(expr, basestring) for expr in exprs):
@@ -4583,7 +4592,7 @@ def oneOf( strs, caseless=False, useRegex=True ):
     symbols = []
     if isinstance(strs,basestring):
         symbols = strs.split()
-    elif isinstance(strs, collections.Iterable):
+    elif isinstance(strs, Iterable):
         symbols = list(strs)
     else:
         warnings.warn("Invalid argument to oneOf, expected string or iterable",


### PR DESCRIPTION
Fixes https://sourceforge.net/p/pyparsing/bugs/106/.

With Python 3.7, I'm getting:
```
/usr/local/lib/python3.7/site-packages/pkg_resources/_vendor/pyparsing.py:943: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  collections.MutableMapping.register(ParseResults)
/usr/local/lib/python3.7/site-packages/pkg_resources/_vendor/pyparsing.py:3245: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  elif isinstance( exprs, collections.Iterable ):
```

This PR fixes it.

The tests pass for me on macOS High Sierra with Python 2.7 and 3.7:

```
⌂107% [hugo:/tmp/pyparsing] patch-2 ± python2 unitTests.py
Beginning test of pyparsing, version 2.2.0
Python version 2.7.15 (default, Jun 17 2018, 12:46:58)
[GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
...............................................................................................................................................................
----------------------------------------------------------------------
Ran 159 tests in 3.310s

OK
⌂111% [hugo:/tmp/pyparsing] patch-2 4s ± python3 unitTests.py
Beginning test of pyparsing, version 2.2.0
Python version 3.7.0 (default, Jun 29 2018, 20:13:13)
[Clang 9.1.0 (clang-902.0.39.2)]
...............................................................................................................................................................
----------------------------------------------------------------------
Ran 159 tests in 3.685s

OK
```
