### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(# Distribution meta-data
     download_url = "https://pypi.org/project/pyparsing/",
     license = "MIT License",
     py_modules = modules,
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
When old Python versions are dropped, this will help pip install the right version for people still running those old Python versions.
 
For more info on how this works:
* https://hackernoon.com/phasing-out-python-runtimes-gracefully-956f112f33c4
* https://github.com/pypa/python-packaging-user-guide/issues/450
