### PR TITLE
Undefined name: file() was removed in Python 3

### DIFF
--- a/unitTests.py
+++ b/unitTests.py
@@ -3902,7 +3902,7 @@ if console:
 else:
     # HTML mode
     outfile = "testResults.html"
-    outstream = file(outfile,"w")
+    outstream = open(outfile,"w")
     testRunner = HTMLTestRunner.HTMLTestRunner( stream=outstream )
     testRunner.run( makeTestSuite() )
     outstream.close()


### PR DESCRIPTION
The _builtin_ __file()__ was removed in Python 3 so this PR advocates the use of __open()__ instead.

Also note that four lines above, __testclass__ is an _undefined name_ and perhaps __testclasses__ should be used in its place.

Undefined names have the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/pyparsing/pyparsing on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./unitTests.py:3901:60: F821 undefined name 'testclass'
            lp.run("testRunner.run( makeTestSuite(%s) )" % testclass.__name__)
                                                           ^
./unitTests.py:3905:17: F821 undefined name 'file'
    outstream = file(outfile,"w")
                ^
2    F821 undefined name 'testclass'
2
```