### PR TITLE
Not sure how I managed to screw up building documentation again.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include pyparsing.py
 include HowToUsePyparsing.html pyparsingClassDiagram.*
 include README.md CODE_OF_CONDUCT.md CHANGES LICENSE
 include examples/*.py examples/Setup.ini examples/*.dfm examples/*.ics examples/*.html
-include docs/*
-include test/*
+recursive-include docs *
+prune docs/_build/*
+recursive-include test *
 include simple_unit_tests.py unitTests.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
+sys.path.insert(0, os.path.abspath('..'))
 
 from pyparsing import __version__ as pyparsing_version
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to PyParsing's documentation!
-=====================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
    :maxdepth: 2
@@ -16,7 +16,7 @@ Welcome to PyParsing's documentation!
 
 
 Indices and tables
-==================
+~~~~~~~~~~~~~~~~~~
 
 * :ref:`genindex`
 * :ref:`modindex`


### PR DESCRIPTION
I am sorry, but this should be [really tested to work](https://build.opensuse.org/package/show/devel:languages:python/python-pyparsing).