### PR TITLE
Remove distutils fallback and outdated comment

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,9 @@ Version 2.3.1 -
   for running tests that do additional validation or processing on the parsed
   results.
 
+- Removed distutils fallback in setup.py. If installing the package fails,
+  please update to the latest version of setuptools.
+
 
 Version 2.3.0 - October, 2018
 -----------------------------

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,9 @@
 
 """Setup script for the pyparsing module distribution."""
 
-# Setuptools depends on pyparsing (via packaging) as of version 34, so allow
-# installing without it to avoid bootstrap problems.
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
-import sys
-import os
-
+from setuptools import setup
 from pyparsing import __version__ as pyparsing_version
-    
+
 modules = ["pyparsing",]
 
 setup(# Distribution meta-data


### PR DESCRIPTION
setuptools includes a vendored version of pyparsing (and other
dependencies). They are not install through traditional tools.
Therefore, distutils is not required as fallback to facilitate
setuptools.

https://github.com/pypa/setuptools/blob/v40.6.3/setuptools/_vendor/pyparsing.py

Also remove the unused imports.