### PR TITLE
Fix encoding cookie to use encoding "utf-8"

### DIFF
--- a/examples/holaMundo.py
+++ b/examples/holaMundo.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 # escrito por Marco Alfonso, 2004 Noviembre
 

--- a/unitTests.py
+++ b/unitTests.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 #
 # unitTests.py
 #


### PR DESCRIPTION
The all caps "UTF-8" causes warnings or errors in some editors. "utf-8" is more widely recognized. For example, when opening files in Emacs, I see:

> Warning (mule): Invalid coding system ‘UTF-8’ is specified
> for the current buffer/file by the :coding tag.
> It is highly recommended to fix it before writing to a file.
> Really proceed with writing? (yes or no)

I'm then promped before saving.

The CPython source code uses the lowecase form.