### PR TITLE
Remove unused imports throughout project

### DIFF
--- a/examples/LAparser.py
+++ b/examples/LAparser.py
@@ -57,11 +57,10 @@ Usage: To process LA equations embedded in source files, import this module and
 
 """
 
-import re,os,sys
+import re,sys
 from pyparsing import Word, alphas, ParseException, Literal, CaselessLiteral \
-, Combine, Optional, nums, Or, Forward, OneOrMore, ZeroOrMore, \
-  FollowedBy, StringStart, StringEnd, alphanums
-import math
+, Combine, Optional, nums, Forward, ZeroOrMore, \
+  StringEnd, alphanums
 
 # Debugging flag can be set to either "debug_flag=True" or "debug_flag=False"
 debug_flag=False

--- a/examples/antlr_grammar.py
+++ b/examples/antlr_grammar.py
@@ -10,7 +10,7 @@ Submitted by Luca DallOlio, September, 2010
 '''
 from pyparsing import Word, ZeroOrMore, printables, Suppress, OneOrMore, Group, \
     LineEnd, Optional, White, originalTextFor, hexnums, nums, Combine, Literal, Keyword, \
-    cStyleComment, Regex, Forward, MatchFirst, And, srange, oneOf, alphas, alphanums, \
+    cStyleComment, Regex, Forward, MatchFirst, And, oneOf, alphas, alphanums, \
     delimitedList
 
 # http://www.antlr.org/grammar/ANTLR/ANTLRv3.g

--- a/examples/dfmparse.py
+++ b/examples/dfmparse.py
@@ -10,7 +10,7 @@ __author__ = "Daniel 'Dang' Griffith <pythondev - dang at lazytwinacres . net>"
 
 from pyparsing import Literal, CaselessLiteral, Word, delimitedList \
     , Optional, Combine, Group, alphas, nums, alphanums, Forward \
-    , oneOf, sglQuotedString, OneOrMore, ZeroOrMore, CharsNotIn
+    , oneOf, OneOrMore, ZeroOrMore, CharsNotIn
 
 
 # This converts DFM character constants into Python string (unicode) values.

--- a/examples/dictExample2.py
+++ b/examples/dictExample2.py
@@ -7,7 +7,6 @@
 # Copyright (c) 2004, Paul McGuire
 #
 from pyparsing import Literal, Word, Group, Dict, ZeroOrMore, alphas, nums, delimitedList, pyparsing_common
-import pprint
 
 testData = """
 +-------+------+------+------+------+------+------+------+------+

--- a/examples/excelExpr.py
+++ b/examples/excelExpr.py
@@ -5,7 +5,7 @@
 # A partial implementation of a parser of Excel formula expressions.
 #
 from pyparsing import (CaselessKeyword, Suppress, Word, alphas,
-    alphanums, nums, Optional, Group, oneOf, Forward, Regex,
+    alphanums, nums, Optional, Group, oneOf, Forward,
     infixNotation, opAssoc, dblQuotedString, delimitedList,
     Combine, Literal, QuotedString, ParserElement, pyparsing_common)
 ParserElement.enablePackrat()

--- a/examples/fourFn.py
+++ b/examples/fourFn.py
@@ -9,8 +9,8 @@
 #
 # Copyright 2003-2009 by Paul McGuire
 #
-from pyparsing import Literal,CaselessLiteral,Word,Group,Optional,\
-    ZeroOrMore,Forward,nums,alphas,alphanums,Regex,ParseException,\
+from pyparsing import Literal,Word,Group,\
+    ZeroOrMore,Forward,alphas,alphanums,Regex,ParseException,\
     CaselessKeyword, Suppress
 import math
 import operator

--- a/examples/getNTPserversNew.py
+++ b/examples/getNTPserversNew.py
@@ -6,7 +6,7 @@
 # Copyright 2004-2010, by Paul McGuire
 # September, 2010 - updated to more current use of setResultsName, new NIST URL
 #
-from pyparsing import (Word, Combine, Suppress, SkipTo, nums, makeHTMLTags,
+from pyparsing import (Word, Combine, SkipTo, nums, makeHTMLTags,
                         delimitedList, alphas, alphanums)
 try:
     import urllib.request

--- a/examples/idlParse.py
+++ b/examples/idlParse.py
@@ -6,9 +6,9 @@
 # Copyright (c) 2003, Paul McGuire
 #
 
-from pyparsing import Literal, CaselessLiteral, Word, OneOrMore, ZeroOrMore, \
-        Forward, NotAny, delimitedList, oneOf, Group, Optional, Combine, alphas, nums, restOfLine, cStyleComment, \
-        alphanums, printables, empty, quotedString, ParseException, ParseResults, Keyword, Regex
+from pyparsing import Literal, Word, OneOrMore, ZeroOrMore, \
+        Forward, delimitedList, Group, Optional, alphas, restOfLine, cStyleComment, \
+        alphanums, quotedString, ParseException, Keyword, Regex
 import pprint
 #~ import tree2image
 

--- a/examples/lucene_grammar.py
+++ b/examples/lucene_grammar.py
@@ -8,7 +8,7 @@
 #
 
 from pyparsing import (Literal, CaselessKeyword, Forward, Regex, QuotedString, Suppress,
-    Optional, Group, FollowedBy, infixNotation, opAssoc, ParseException, ParserElement,
+    Optional, Group, infixNotation, opAssoc, ParserElement,
     pyparsing_common)
 ParserElement.enablePackrat()
 

--- a/examples/mozillaCalendarParser.py
+++ b/examples/mozillaCalendarParser.py
@@ -1,4 +1,4 @@
-from pyparsing import Optional, oneOf, Dict, Literal, Word, printables, Group, OneOrMore, ZeroOrMore
+from pyparsing import Optional, oneOf, Literal, Word, printables, Group, OneOrMore, ZeroOrMore
 
 """
 A simple parser for calendar (*.ics) files,

--- a/examples/nested.py
+++ b/examples/nested.py
@@ -7,7 +7,6 @@
 #
 
 from pyparsing import *
-import pprint
 
 data = """
 {

--- a/examples/parseTabularData.py
+++ b/examples/parseTabularData.py
@@ -7,7 +7,7 @@
 #
 # Copyright 2015, Paul McGuire
 #
-from pyparsing import col,Word,Optional,alphas,nums,ParseException
+from pyparsing import col,Word,Optional,alphas,nums
 
 table = """\
          1         2

--- a/examples/pgn.py
+++ b/examples/pgn.py
@@ -10,7 +10,7 @@
 # Copyright 2004, by Alberto Santini http://www.albertosantini.it/chess/
 #
 from pyparsing import alphanums, nums, quotedString
-from pyparsing import Combine, Forward, Group, Literal, oneOf, OneOrMore, Optional, Suppress, ZeroOrMore, White, Word
+from pyparsing import Combine, Forward, Group, Literal, oneOf, OneOrMore, Optional, Suppress, ZeroOrMore, Word
 from pyparsing import ParseException
 
 #

--- a/examples/protobuf_parser.py
+++ b/examples/protobuf_parser.py
@@ -6,7 +6,7 @@
 #
 
 from pyparsing import (Word, alphas, alphanums, Regex, Suppress, Forward,
-    Group, oneOf, ZeroOrMore, Optional, delimitedList, Keyword,
+    Group, oneOf, ZeroOrMore, Optional, delimitedList,
     restOfLine, quotedString, Dict)
 
 ident = Word(alphas+"_",alphanums+"_").setName("identifier")

--- a/examples/pymicko.py
+++ b/examples/pymicko.py
@@ -18,7 +18,7 @@
 #    A copy of the GNU General Public License can be found at <http://www.gnu.org/licenses/>.
 
 from pyparsing import *
-from sys import stdin, stdout, stderr, argv, exit
+from sys import stdin, argv, exit
 
 #defines debug level
 # 0 - no debug

--- a/examples/rangeCheck.py
+++ b/examples/rangeCheck.py
@@ -8,7 +8,7 @@
 # Copyright 2011,2015 Paul T. McGuire
 #
 
-from pyparsing import Word, nums, Suppress, ParseException, empty, Optional
+from pyparsing import Word, nums, Suppress, Optional
 from datetime import datetime
 
 def ranged_value(expr, minval=None, maxval=None):

--- a/examples/searchparser.py
+++ b/examples/searchparser.py
@@ -57,7 +57,7 @@ TODO:
 - ask someone to check my English texts
 - add more kinds of wildcards ('*' at the beginning and '*' inside a word)?
 """
-from pyparsing import Word, alphanums, Keyword, Group, Combine, Forward, Suppress, Optional, OneOrMore, oneOf
+from pyparsing import Word, alphanums, Keyword, Group, Combine, Forward, Suppress, OneOrMore, oneOf
 
 class SearchQueryParser:
 

--- a/examples/simpleSQL.py
+++ b/examples/simpleSQL.py
@@ -5,8 +5,8 @@
 #
 # Copyright (c) 2003,2016, Paul McGuire
 #
-from pyparsing import Literal, CaselessLiteral, Word, delimitedList, Optional, \
-    Combine, Group, alphas, nums, alphanums, ParseException, Forward, oneOf, quotedString, \
+from pyparsing import Word, delimitedList, Optional, \
+    Group, alphas, alphanums, Forward, oneOf, quotedString, \
     ZeroOrMore, restOfLine, CaselessKeyword, pyparsing_common
 
 # define SQL tokens

--- a/examples/sparser.py
+++ b/examples/sparser.py
@@ -47,8 +47,6 @@ EXAMPLES:
 import sys
 import os
 import getopt
-import re
-import gzip
 
 from pyparsing import *
 

--- a/examples/sql2dot.py
+++ b/examples/sql2dot.py
@@ -47,9 +47,9 @@ alter table only student_registrations
     (class_id) references classes(class_id);
 """.upper()
 
-from pyparsing import Literal, CaselessLiteral, Word, delimitedList \
-    ,Optional, Combine, Group, alphas, nums, alphanums, Forward \
-    , oneOf, sglQuotedString, OneOrMore, ZeroOrMore, CharsNotIn \
+from pyparsing import Literal, Word, delimitedList \
+    , alphas, alphanums \
+    , OneOrMore, ZeroOrMore, CharsNotIn \
     , replaceWith
 
 skobki = "(" + ZeroOrMore(CharsNotIn(")")) + ")"

--- a/examples/stackish.py
+++ b/examples/stackish.py
@@ -29,7 +29,7 @@ SPACE White space is basically ignored. This is interesting because since
 """
 
 from pyparsing import Suppress,Word,nums,alphas,alphanums,Combine,oneOf,\
-        Optional,QuotedString,Forward,Group,ZeroOrMore,printables,srange
+        Optional,QuotedString,Forward,Group,ZeroOrMore,srange
 
 MARK,UNMARK,AT,COLON,QUOTE = map(Suppress,"[]@:'")
 

--- a/examples/stateMachine2.py
+++ b/examples/stateMachine2.py
@@ -2,7 +2,6 @@
 #
 # module to define .pystate import handler
 #
-#import imputil
 import sys
 import os
 import types
@@ -10,11 +9,9 @@ import urllib.parse
 
 DEBUG = False
 
-from pyparsing import Word, Group, ZeroOrMore, alphas, \
-    alphanums, ParserElement, ParseException, ParseSyntaxException, \
-    Empty, LineEnd, OneOrMore, col, Keyword, pythonStyleComment, \
-    StringEnd, traceParseAction
-
+from pyparsing import Word, Group, alphas, \
+    alphanums, ParseException, \
+    OneOrMore, col, Keyword, pythonStyleComment
 
 ident = Word(alphas+"_", alphanums+"_$")
 

--- a/examples/test_bibparse.py
+++ b/examples/test_bibparse.py
@@ -1,12 +1,10 @@
 """ Test for bibparse grammar """
 
-from os.path import join as pjoin, dirname
-
 from pyparsing import ParseException
 from .btpyparse import Macro
 from . import btpyparse as bp
 
-from nose.tools import assert_true, assert_false, assert_equal, assert_raises
+from nose.tools import assert_equal, assert_raises
 
 
 def test_names():

--- a/examples/urlExtractorNew.py
+++ b/examples/urlExtractorNew.py
@@ -1,7 +1,6 @@
 # URL extractor
 # Copyright 2004, Paul McGuire
-from pyparsing import Literal,Suppress,CharsNotIn,CaselessLiteral,\
-        Word,dblQuotedString,alphanums,SkipTo,makeHTMLTags
+from pyparsing import SkipTo, makeHTMLTags
 import urllib.request, urllib.parse, urllib.error
 import pprint
 

--- a/examples/verilogParse.py
+++ b/examples/verilogParse.py
@@ -61,17 +61,16 @@
 #           for udpInstance.
 #   1.0.11 - Fixed bug in inst_args, content alternatives were reversed
 #
-import pdb
 import time
 import pprint
 import sys
 
 __version__ = "1.0.11"
 
-from pyparsing import Literal, CaselessLiteral, Keyword, Word, OneOrMore, ZeroOrMore, \
-        Forward, NotAny, delimitedList, Group, Optional, Combine, alphas, nums, restOfLine, cStyleComment, \
-        alphanums, printables, dblQuotedString, empty, ParseException, ParseResults, MatchFirst, oneOf, GoToColumn, \
-        ParseResults,StringEnd, FollowedBy, ParserElement, And, Regex, cppStyleComment#,__version__
+from pyparsing import Literal, Keyword, Word, OneOrMore, ZeroOrMore, \
+        Forward, delimitedList, Group, Optional, Combine, alphas, nums, restOfLine, \
+        alphanums, dblQuotedString, empty, ParseException, oneOf, \
+        StringEnd, FollowedBy, ParserElement, Regex, cppStyleComment
 import pyparsing
 usePackrat = False
 usePsyco = False

--- a/pyparsing.py
+++ b/pyparsing.py
@@ -109,7 +109,7 @@ import pprint
 import traceback
 import types
 from datetime import datetime
-from itertools import takewhile
+
 try:
     # Python 3
     from itertools import filterfalse

--- a/unitTests.py
+++ b/unitTests.py
@@ -13,7 +13,6 @@ from pyparsing import ParseException
 import pyparsing as pp
 
 import sys
-import pdb
 
 PY_3 = sys.version.startswith('3')
 if PY_3:
@@ -273,7 +272,6 @@ class ParseJSONDataTest(ParseTestCase):
             [],
             ]
 
-        import pprint
         for t,exp in zip((test1,test2,test3,test4,test5),expected):
             result = jsonObject.parseString(t)
 ##            print result.dump()
@@ -285,7 +283,6 @@ class ParseJSONDataTest(ParseTestCase):
 class ParseCommaSeparatedValuesTest(ParseTestCase):
     def runTest(self):
         from pyparsing import commaSeparatedList
-        import string
 
         testData = [
             "a,b,c,100.2,,3",
@@ -316,7 +313,7 @@ class ParseCommaSeparatedValuesTest(ParseTestCase):
 class ParseEBNFTest(ParseTestCase):
     def runTest(self):
         from examples import ebnf
-        from pyparsing import Word, quotedString, alphas, nums,ParserElement
+        from pyparsing import Word, quotedString, alphas, nums
 
         print_('Constructing EBNF parser with pyparsing...')
 
@@ -989,7 +986,7 @@ class ReStringRangeTest(ParseTestCase):
 class SkipToParserTests(ParseTestCase):
     def runTest(self):
 
-        from pyparsing import Literal, SkipTo, NotAny, cStyleComment, ParseBaseException
+        from pyparsing import Literal, SkipTo, cStyleComment, ParseBaseException
 
         thingToFind = Literal('working')
         testExpr = SkipTo(Literal(';'), include=True, ignore=cStyleComment) + thingToFind
@@ -1068,7 +1065,7 @@ class CustomQuotesTest(ParseTestCase):
 
 class RepeaterTest(ParseTestCase):
     def runTest(self):
-        from pyparsing import matchPreviousLiteral,matchPreviousExpr, Forward, Literal, Word, alphas, nums, ParserElement
+        from pyparsing import matchPreviousLiteral,matchPreviousExpr, Word, nums, ParserElement
 
         if ParserElement._packratEnabled:
             print_("skipping this test, not compatible with packratting")
@@ -1406,7 +1403,7 @@ class InfixNotationGrammarTest4(ParseTestCase):
 class InfixNotationGrammarTest5(ParseTestCase):
 
     def runTest(self):
-        from pyparsing import infixNotation, opAssoc, pyparsing_common, Literal, oneOf, ParseResults
+        from pyparsing import infixNotation, opAssoc, pyparsing_common, Literal, oneOf
 
         expop = Literal('**')
         signop = oneOf('+ -')
@@ -2267,7 +2264,7 @@ class OriginalTextForTest(ParseTestCase):
 
 class PackratParsingCacheCopyTest(ParseTestCase):
     def runTest(self):
-        from pyparsing import Word,nums,ParserElement,delimitedList,Literal,Optional,alphas,alphanums,ZeroOrMore,empty
+        from pyparsing import Word,nums,delimitedList,Literal,Optional,alphas,alphanums,ZeroOrMore,empty
 
         integer = Word(nums).setName("integer")
         id = Word(alphas+'_',alphanums+'_')
@@ -2288,7 +2285,7 @@ class PackratParsingCacheCopyTest(ParseTestCase):
 
 class PackratParsingCacheCopyTest2(ParseTestCase):
     def runTest(self):
-        from pyparsing import Keyword,Word,Suppress,Forward,Optional,delimitedList,ParserElement,Group
+        from pyparsing import Keyword,Word,Suppress,Forward,Optional,delimitedList,Group
 
         DO,AA = list(map(Keyword, "DO AA".split()))
         LPAR,RPAR = list(map(Suppress,"()"))
@@ -2639,7 +2636,7 @@ class OptionalEachTest(ParseTestCase):
                          + str(p1res.asList()) + " should match " + str(p2res.asList()))
 
     def runTest2(self):
-        from pyparsing import Word, alphanums, Suppress, OneOrMore, Group, Regex, Optional
+        from pyparsing import Word, alphanums, OneOrMore, Group, Regex, Optional
 
         word = Word(alphanums + '_').setName("word")
         with_stmt = 'with' + OneOrMore(Group(word('key') + '=' + word('value')))('overrides')
@@ -2736,7 +2733,7 @@ class MarkInputLineTest(ParseTestCase):
 
         samplestr1 = "DOB 100-10-2010;more garbage\nID PARI12345678;more garbage"
 
-        from pyparsing import Regex, Word, alphanums, restOfLine
+        from pyparsing import Regex
         dob_ref = "DOB" + Regex(r"\d{2}-\d{2}-\d{4}")("dob")
 
         try:
@@ -2754,7 +2751,7 @@ class LocatedExprTest(ParseTestCase):
         #             012345678901234567890123456789012345678901234567890
         samplestr1 = "DOB 10-10-2010;more garbage;ID PARI12345678  ;more garbage"
 
-        from pyparsing import Regex, Word, alphanums, restOfLine, locatedExpr
+        from pyparsing import Word, alphanums, locatedExpr
         id_ref = locatedExpr("ID" + Word(alphanums,exact=12)("id"))
 
         res = id_ref.searchString(samplestr1)[0][0]
@@ -2802,7 +2799,7 @@ class PopTest(ParseTestCase):
 
 class AddConditionTest(ParseTestCase):
     def runTest(self):
-        from pyparsing import Word, alphas, nums, Suppress, ParseFatalException
+        from pyparsing import Word, nums, Suppress, ParseFatalException
 
         numParser = Word(nums)
         numParser.addParseAction(lambda s,l,t: int(t[0]))


### PR DESCRIPTION
Unused imports were discovered using flake8. By removing the unused imports, the code is a bit friendlier to new contributors as it is clearer what is being used and not simply leftover from previous
refactoring.

The flake8 command:

```
$ flake8 . --select F401
```

http://flake8.pycqa.org/