### PR TITLE
Replace bare 'except:' with 'except Exception;'

### DIFF
--- a/examples/LAparser.py
+++ b/examples/LAparser.py
@@ -404,7 +404,7 @@ if __name__ == '__main__':
     else:
       try:
         print(parse(input_string))
-      except:
+      except Exception:
         pass
 
     # obtain new input string

--- a/examples/dfmparse.py
+++ b/examples/dfmparse.py
@@ -161,7 +161,7 @@ def main(testfiles=None, action=printer):
         try:
             retval[f] = object_definition.parseFile(f)
             success += 1
-        except:
+        except Exception:
             failures.append(f)
 
     if failures:

--- a/examples/pythonGrammarParser.py
+++ b/examples/pythonGrammarParser.py
@@ -170,7 +170,7 @@ def makeGroupObject(cls):
     def groupAction(s,l,t):
         try:
             return cls(t[0].asList())
-        except:
+        except Exception:
             return cls(t)
     return groupAction
 

--- a/examples/verilogParse.py
+++ b/examples/verilogParse.py
@@ -81,7 +81,7 @@ psycoOn = False
 if usePackrat:
     try:
         ParserElement.enablePackrat()
-    except:
+    except Exception:
         pass
     else:
         packratOn = True
@@ -91,7 +91,7 @@ if usePsyco:
     try:
         import psyco
         psyco.full()
-    except:
+    except Exception:
         print("failed to import psyco Python optimizer")
     else:
         psycoOn = True

--- a/unitTests.py
+++ b/unitTests.py
@@ -850,7 +850,7 @@ class ParseKeywordTest(ParseTestCase):
             print_("Match Literal", end=' ')
             try:
                 print_(lit.parseString(s))
-            except:
+            except Exception:
                 print_("failed")
                 if litShouldPass:
                     self.assertTrue(False, "Literal failed to match %s, should have" % s)
@@ -861,7 +861,7 @@ class ParseKeywordTest(ParseTestCase):
             print_("Match Keyword", end=' ')
             try:
                 print_(kw.parseString(s))
-            except:
+            except Exception:
                 print_("failed")
                 if kwShouldPass:
                     self.assertTrue(False, "Keyword failed to match %s, should have" % s)
@@ -3939,10 +3939,10 @@ class MiscellaneousParserTests(ParseTestCase):
                 print_(t, repr(t))
                 try:
                     names.append( t[0].getName() )
-                except:
+                except Exception:
                     try:
                         names.append( t.getName() )
-                    except:
+                    except Exception:
                         names.append( None )
             print_(teststring)
             print_(names)


### PR DESCRIPTION
Catching all exceptions is generally considered a bad practice under most circumstances as it will also catch `KeyboardInterrupt` and `SystemExit`. These special cases should be raised to the interpreter to
allow the Python process to exit.

This fix complies with pycodestyle's error code E722:

https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes

> do not use bare except, specify exception instead