### PR TITLE
Remove mentions of 'psyco' from docs and examples

### DIFF
--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -226,13 +226,6 @@ Usage notes
   or expressions that may occur within an ``And`` expression; an early element
   of an ``And`` may match, but the overall expression may fail.
 
-- Performance of pyparsing may be slow for complex grammars and/or large
-  input strings.  The psyco_ package can be used to improve the speed of the
-  pyparsing module with no changes to grammar or program logic - observed
-  improvments have been in the 20-50% range.
-
-.. _psyco: http://psyco.sourceforge.net/
-
 
 Classes
 =======
@@ -363,11 +356,8 @@ methods for code to use are:
   performance enhancement, known as "packrat parsing".  packrat parsing is
   disabled by default, since it may conflict with some user programs that use
   parse actions.  To activate the packrat feature, your
-  program must call the class method ParserElement.enablePackrat().  If
-  your program uses psyco to "compile as you go", you must call
-  enablePackrat before calling psyco.full().  If you do not do this,
-  Python will crash.  For best results, call enablePackrat() immediately
-  after importing pyparsing.
+  program must call the class method ParserElement.enablePackrat(). For best
+  results, call enablePackrat() immediately after importing pyparsing.
 
 
 Basic ParserElement subclasses

--- a/examples/verilogParse.py
+++ b/examples/verilogParse.py
@@ -73,10 +73,8 @@ from pyparsing import Literal, Keyword, Word, OneOrMore, ZeroOrMore, \
         StringEnd, FollowedBy, ParserElement, Regex, cppStyleComment
 import pyparsing
 usePackrat = False
-usePsyco = False
 
 packratOn = False
-psycoOn = False
 
 if usePackrat:
     try:
@@ -85,16 +83,6 @@ if usePackrat:
         pass
     else:
         packratOn = True
-
-# comment out this section to disable psyco function compilation
-if usePsyco:
-    try:
-        import psyco
-        psyco.full()
-    except:
-        print("failed to import psyco Python optimizer")
-    else:
-        psycoOn = True
 
 
 def dumpTokens(s,l,t):
@@ -637,7 +625,6 @@ else:
         print(" - using pyparsing version", pyparsing.__version__)
         print(" - using Python version", sys.version)
         if packratOn: print(" - using packrat parsing")
-        if psycoOn: print(" - using psyco runtime optimization")
         print()
 
         import os

--- a/pyparsing.py
+++ b/pyparsing.py
@@ -1677,11 +1677,9 @@ class ParserElement(object):
            This speedup may break existing programs that use parse actions that
            have side-effects.  For this reason, packrat parsing is disabled when
            you first import pyparsing.  To activate the packrat feature, your
-           program must call the class method :class:`ParserElement.enablePackrat`.  If
-           your program uses ``psyco`` to "compile as you go", you must call
-           ``enablePackrat`` before calling ``psyco.full()``.  If you do not do this,
-           Python will crash.  For best results, call ``enablePackrat()`` immediately
-           after importing pyparsing.
+           program must call the class method :class:`ParserElement.enablePackrat`.
+           For best results, call ``enablePackrat()`` immediately after
+           importing pyparsing.
 
            Example::
 


### PR DESCRIPTION
The psyco package has been declared umaintained and dead. It is no longer receiving bug fixes including for security issues. From http://psyco.sourceforge.net/

> 12 March 2012
>
> Psyco is unmaintained and dead. Please look at PyPy for the state-of-the-art in JIT compilers for Python.

Avoid recommending the use of an unmaintained package (since 2012). Users can continue to use PyPy for the latest and greatest in Python JIT.