### PR TITLE
Support for simple_unit_tests under Python 2

### DIFF
--- a/pyparsing.py
+++ b/pyparsing.py
@@ -350,7 +350,11 @@ class ParseException(ParseBaseException):
             callers = inspect.getinnerframes(exc.__traceback__, context=depth)
             seen = set()
             for i, ff in enumerate(callers[-depth:]):
-                frm = ff.frame
+                if isinstance(ff, tuple):
+                    # Python 2 compatibility
+                    frm = ff[0]
+                else:
+                    frm = ff.frame
 
                 f_self = frm.f_locals.get('self', None)
                 if isinstance(f_self, ParserElement):

--- a/simple_unit_tests.py
+++ b/simple_unit_tests.py
@@ -29,6 +29,15 @@ class PyparsingExpressionTestCase(unittest.TestCase):
     given text strings. Subclasses must define a class attribute 'tests' which
     is a list of PpTestSpec instances.
     """
+    
+    if not hasattr(unittest.TestCase, 'subTest'):
+        # Python 2 compatibility
+        from contextlib import contextmanager
+        @contextmanager
+        def subTest(self, **params):
+            print('subTest:', params)
+            yield
+    
     tests = []
     def runTest(self):
         if self.__class__ is PyparsingExpressionTestCase:
@@ -75,6 +84,11 @@ class PyparsingExpressionTestCase(unittest.TestCase):
                     try:
                         parsefn(test_spec.text)
                     except Exception as exc:
+                        if not hasattr(exc, '__traceback__'):
+                            # Python 2 compatibility
+                            from sys import exc_info
+                            etype, value, traceback = exc_info()
+                            exc.__traceback__ = traceback
                         print(pp.ParseException.explain(exc))
                         self.assertEqual(exc.loc, test_spec.expected_fail_locn)
                     else:
@@ -434,12 +448,6 @@ class TestCommonHelperExpressions(PyparsingExpressionTestCase):
 #============ MAIN ================
 
 if __name__ == '__main__':
-    # we use unittest features that are in Py3 only, bail out if run on Py2
-    import sys
-    if sys.version_info[0] < 3:
-        print("simple_unit_tests.py runs on Python 3 only")
-        sys.exit(0)
-
     import inspect
     def get_decl_line_no(cls):
         return inspect.getsourcelines(cls)[1]


### PR DESCRIPTION
This might not be too desirable with the end of life right around the corner, but the incompatibilities weren't too tricky to deal with for the purposes of simply running the suite.  Granted, the traceback sent to `explain` is probably the wrong one, and the `subTest` shim isn't fully functional, but at least the file passes.