### PR TITLE
snmp_api.h missing from manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include pyparsing.py
 include HowToUsePyparsing.html pyparsingClassDiagram.*
 include README.md CODE_OF_CONDUCT.md CHANGES LICENSE
-include examples/*.py examples/Setup.ini examples/*.dfm examples/*.ics examples/*.html
+include examples/*.py examples/Setup.ini examples/*.dfm examples/*.ics examples/*.html examples/*.h
 recursive-include docs *
 prune docs/_build/*
 recursive-include test *


### PR DESCRIPTION
Add examples/*.h to manifest so snmp_api.h gets packaged with the rest of the test files.
Noticed when attempting to run "python3 setup.py test" against 2.3.1 tarball.