### PR TITLE
Support for omitted integer part of the float number

### DIFF
--- a/pyparsing.py
+++ b/pyparsing.py
@@ -6153,7 +6153,7 @@ class pyparsing_common:
     """mixed integer of the form 'integer - fraction', with optional leading integer, returns float"""
     mixed_integer.addParseAction(sum)
 
-    real = Regex(r'[+-]?\d+\.\d*').setName("real number").setParseAction(convertToFloat)
+    real = Regex(r'[+-]?\d*\.\d*').setName("real number").setParseAction(convertToFloat)
     """expression that parses a floating point number and returns a float"""
 
     sci_real = Regex(r'[+-]?\d+([eE][+-]?\d+|\.\d*([eE][+-]?\d+)?)').setName("real number with scientific notation").setParseAction(convertToFloat)

--- a/pyparsing.py
+++ b/pyparsing.py
@@ -6156,7 +6156,7 @@ class pyparsing_common:
     real = Regex(r'[+-]?\d*\.\d*').setName("real number").setParseAction(convertToFloat)
     """expression that parses a floating point number and returns a float"""
 
-    sci_real = Regex(r'[+-]?\d+([eE][+-]?\d+|\.\d*([eE][+-]?\d+)?)').setName("real number with scientific notation").setParseAction(convertToFloat)
+    sci_real = Regex(r'[+-]?\d*([eE][+-]?\d+|\.\d*([eE][+-]?\d+)?)').setName("real number with scientific notation").setParseAction(convertToFloat)
     """expression that parses a floating point number with optional
     scientific notation and returns a float"""
 


### PR DESCRIPTION
When writing float numbers, integer part can be omitted, in which case it defaults to 0. Thus, `.123456` and `-.123456` are valid floats, equalling to 0.123456 and -0.123456, respectively. However, `pyparsing` does not support such notation. This pull request changes the quantifier of the `pyparsing_common.real` integer part regex token, adding support for such numbers.