### PR TITLE
Revise ParserElement.parseString docstring

### DIFF
--- a/pyparsing.py
+++ b/pyparsing.py
@@ -1793,38 +1793,43 @@ class ParserElement(object):
                 ParserElement.packrat_cache = ParserElement._FifoCache(cache_size_limit)
             ParserElement._parse = ParserElement._parseCache
 
-    def parseString( self, instring, parseAll=False ):
+    def parseString(self, instring, parseAll=False):
         """
-        Execute the parse expression with the given string.
-        This is the main interface to the client code, once the complete
-        expression has been built.
+        Parse a string with respect to the parser definition. This function is intended as the primary interface to the
+        client code.
 
-        Returns the parsed data as a :class:`ParseResults` object, which may be
-        accessed as a list, or as a dict or object with attributes if the given parser
-        includes results names.
+        :param instring: The input string to be parsed.
+        :param parseAll: If set, the entire input string must match the grammar.
 
-        If you want the grammar to require that the entire input string be
-        successfully parsed, then set ``parseAll`` to True (equivalent to ending
-        the grammar with ``StringEnd()``).
+        :raises ParseException: Raised if ``parseAll`` is set and the input string does not match the whole grammar.
 
-        Note: ``parseString`` implicitly calls ``expandtabs()`` on the input string,
-        in order to report proper column numbers in parse actions.
-        If the input string contains tabs and
-        the grammar uses parse actions that use the ``loc`` argument to index into the
-        string being parsed, you can ensure you have a consistent view of the input
-        string by:
+        :returns: the parsed data as a :class:`ParseResults` object, which may be accessed as a `list`, a `dict`, or
+        an object with attributes if the given parser includes results names.
 
-        - calling ``parseWithTabs`` on your grammar before calling ``parseString``
-          (see :class:`parseWithTabs`)
-        - define your parse action using the full ``(s,loc,toks)`` signature, and
-          reference the input string using the parse action's ``s`` argument
-        - explictly expand the tabs in your input string before calling
-          ``parseString``
+        If the input string is required to match the entire grammar, ``parseAll`` flag must be set to True. This
+        is also equivalent to ending the grammar with ``StringEnd()``.
 
-        Example::
+        To report proper column numbers, ``parseString`` operates on a copy of the input string where all tabs are
+        converted to spaces (8 spaces per tab, as per the default in ``string.expandtabs``). If the input string
+        contains tabs and the grammar uses parse actions that use the ``loc`` argument to index into the string
+        being parsed, one can ensure a consistent view of the input string by doing one of the following:
 
-            Word('a').parseString('aaaaabaaa')  # -> ['aaaaa']
-            Word('a').parseString('aaaaabaaa', parseAll=True)  # -> Exception: Expected end of text
+        - calling ``parseWithTabs`` on your grammar before calling ``parseString`` (see :class:`parseWithTabs`),
+        - define your parse action using the full ``(s,loc,toks)`` signature, and reference the input string using the
+        parse action's ``s`` argument, or
+        - explicitly expand the tabs in your input string before calling ``parseString``.
+
+        Examples:
+
+        By default, partial matches are OK.
+        >>> res = Word('a').parseString('aaaaabaaa')
+        (['aaaaa'], {})
+
+        It raises an exception if parseAll flag is set and instring does not match the whole grammar.
+        >>> Word('a').parseString('aaaaabaaa', parseAll=True)
+        Traceback (most recent call last):
+        ...
+        pyparsing.ParseException: Expected end of text (at char 5), (line:1, col:6)
         """
         ParserElement.resetCache()
         if not self.streamlined:


### PR DESCRIPTION
Hi Paul,

I've revised the said docstring, which contains the following:

* reST-style docstring,
* examples are given as doctests, which is highlighted specially in IDE's, and can be automagically checked to see if they are still correct.
* Fixed some grammar and typo errors.

I've started to delve into the code. If you think this style is a good idea, I shall also arrange the docstrings of the functions that I stumble upon.
 