### PR TITLE
How-To page: 3.x-ify some print statements and an except

### DIFF
--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -59,7 +59,7 @@ or any other greeting of the form "<salutation>, <addressee>!"::
 
     greet = Word(alphas) + "," + Word(alphas) + "!"
     greeting = greet.parseString("Hello, World!")
-    print greeting
+    print(greeting)
 
 The parsed tokens are returned in the following form::
 
@@ -691,10 +691,10 @@ Exception classes and Troubleshooting
   ParseExceptions have attributes loc, msg, line, lineno, and column; to view the
   text line and location where the reported ParseException occurs, use::
 
-    except ParseException, err:
-        print err.line
-        print " " * (err.column - 1) + "^"
-        print err
+    except ParseException as err:
+        print(err.line)
+        print(" " * (err.column - 1) + "^")
+        print(err)
 
 - ``RecursiveGrammarException`` - exception returned by ``validate()`` if
   the grammar contains a recursive infinite loop, such as::


### PR DESCRIPTION
As part of the effort to make pyparsing more 3.X-oriented, the How To page should be updated.

This change modifies the print statements in code samples so they use 3.X compatible syntax.
`except ParseException, err` also needed to be updated.