### PR TITLE
parseAll implementation by grammar modification

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,10 +1,10 @@
 # This file contains the configuration for Scrutinizer-CI, a tool we use for software quality purposes.
 build:
   environment:
-    python: 3.6.3
+    python: 3.7.2
 
     variables:
-      PYTHON_VERSIONS: 'jython-2.7.1 pypy2.7-5.10.0 pypy3.5-5.10.1 2.7.15 3.3.6 3.4.5 3.5.6'
+      PYTHON_VERSIONS: 'pypy3.5-6.0.0 3.5.6 3.6.3'
 
   dependencies:
     override:

--- a/pyparsing.py
+++ b/pyparsing.py
@@ -1752,21 +1752,23 @@ class ParserElement(object):
         ...
         pyparsing.ParseException: Expected end of text, found 'b'  (at char 5), (line:1, col:6)
         """
-        
+        if parseAll:
+            parser = self + StringEnd()
+            return parser.parseString(instring)
+
         ParserElement.resetCache()
+
         if not self.streamlined:
             self.streamline()
-            # ~ self.saveAsList = True
+
         for e in self.ignoreExprs:
             e.streamline()
+
         if not self.keepTabs:
             instring = instring.expandtabs()
+
         try:
             loc, tokens = self._parse(instring, 0)
-            if parseAll:
-                loc = self.preParse(instring, loc)
-                se = Empty() + StringEnd()
-                se._parse(instring, loc)
         except ParseBaseException as exc:
             if ParserElement.verbose_stacktrace:
                 raise

--- a/scrutinizer-pyenv.sh
+++ b/scrutinizer-pyenv.sh
@@ -8,4 +8,4 @@ git fetch --tags
 git checkout v1.2.7
 popd
 
-echo $PYTHON_VERSIONS | xargs -n1 pyenv install
+echo $PYTHON_VERSIONS | xargs -n1 pyenv install -s

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=pypy, pypy3, py27, py33, py34, py35, py36
+envlist=pypy3, py35, py36, py37
 
 [testenv]
 deps=-rrequirements-dev.txt


### PR DESCRIPTION
Hi Paul,

The reason I'm proposing this is the inconsistency in the `ParseException.explain` method, illustrated as follows:

First example, where `parseAll=True`:

```python
expr = Word('012') + Word('abc')
try:
    expr.parseString('00aaf', parseAll=True)
except ParseException as pe:
    print(ParseException.explain(pe))
```

prints

```
00aaf
    ^
ParseException: Expected end of text, found 'f'  (at char 4), (line:1, col:5)
pyparsing.And - {Empty StringEnd}
pyparsing.StringEnd - StringEnd
```

The second example, where the same effect is accomplished with `StringEnd`

```python
expr = Word('012') + Word('abc') + StringEnd()

try:
    expr.parseString('00aaf')
except ParseException as pe:
    print(ParseException.explain(pe))
```

prints

```
00aaf
    ^
ParseException: Expected end of text, found 'f'  (at char 4), (line:1, col:5)
pyparsing.And - {W:(012) W:(abc) StringEnd}
pyparsing.StringEnd - StringEnd
```

Observe the difference in output on line starting with `pyparsing.And`: the first approach parses the leftover string with a grammar defined as `Empty() + StringEnd()`. Upon receiving the exception, the grammar trace reports a grammar that does not have to do with the original grammar description, whereas the second approach clearly indicates a `StringEnd()` has been appended to the original grammar, which I believe is the better output format in an obvious way. 

With this reasoning, I am modifying the implementation of `parseString` so that, if `parseAll==True`, the parser element constructs a new parser by appending `StringEnd()` to itself, and delegating the parsing action to the new parser's `parseString` method.

Please note that this work is not yet ready to be merged, as you can see there aren't any tests added and I am not confident this modification won't break anything. If you give it a go, I shall examine other parser entry to ensure uniform behavior, and make sure it does not break anything.
  


