### PR TITLE
Support building without setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@
 
 """Setup script for the pyparsing module distribution."""
 
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 from pyparsing import __version__ as pyparsing_version, __doc__ as pyparsing_description
 
 modules = ["pyparsing",]


### PR DESCRIPTION
As pyparsing is a dependency used by setuptools this allows packagers to use distutils as a fallback when bootstraping setuptools without much fuss.

The package will be built it will just render the setup.py test not working for anyone not building with setuptools, but that is just a trivial issue i would say.