### PR TITLE
Remove unnecessary keys and overrides from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 
 matrix:
@@ -7,10 +5,8 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
-    - python: 3.8-dev
+    - python: 3.8
     - python: pypy3
-      dist: xenial
-      sudo: true
   fast_finish: true
 
 install:


### PR DESCRIPTION
- The default "dist" is now xenial, can remove the override.
- The "sudo" key is now deprecated and is no longer necessary.
- Python 3.8 final is now available.