### PR TITLE
Add Python 3.8 to the tox matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=pypy3, py35, py36, py37
+envlist=py{35,36,37,38,py3}
 
 [testenv]
 deps=-rrequirements-dev.txt


### PR DESCRIPTION
Allows contributors to easily run the full test matrix locally.

Python 3.8 was released on on October 14th, 2019.

https://docs.python.org/3/whatsnew/3.8.html