### PR TITLE
Add missing trove classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,9 @@ setup(# Distribution meta-data
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         ]
     )


### PR DESCRIPTION
- pyparsing supports Python 3.8
- pyparsing is Python 3 only
- pyparsing supports PyPy in addition to CPython

The trove classifiers display on PyPI and provide quick, at-a-glance
information for library users to know if it is suitable for inclusion in
a project.

For a complete list of trove classifiers, see:

https://pypi.org/classifiers/