### PR TITLE
Remove unused setup.py keywords "test_suite"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,11 @@ Version 3.0.0a1
     to help identify those expressions in your parsers that
     will have changed as a result.
 
+- Removed support for running `python setup.py test`. The setuptools
+  maintainers consider the test command deprecated (see
+  <https://github.com/pypa/setuptools/issues/1684>). To run the Pyparsing test,
+  use the command `tox`.
+
 - POTENTIAL API CHANGE:
   ZeroOrMore expressions that have results names will now
   include empty lists for their name if no matches are found.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,4 @@ include examples/*.py examples/Setup.ini examples/*.dfm examples/*.ics examples/
 recursive-include docs *
 prune docs/_build/*
 recursive-include tests *
-include setup.py
+include setup.py tox.ini

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(# Distribution meta-data
     license = "MIT License",
     py_modules = modules,
     python_requires='>=3.5',
-    test_suite="tests",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The tests are run through either tox or Travis CI. In both cases, the
setup.py "test_suite" entrypoint is not used.

Further, the use of "test_suite" is discouraged as it installs using
eggs rather than pip.