### PR TITLE
Remove 'universal = 1' from [bdist_wheel] section of setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
As pyparsing is now Python 3 only, the wheel is not "universal". A
universal wheel is defined as:

https://wheel.readthedocs.io/en/stable/user_guide.html

> If your project contains no C extensions and is expected to work on
> both Python 2 and 3, you will want to tell wheel to produce universal
> wheels …

As the project is _not_ expected to work on Python 2, it should not be
distributed as a Python 2 wheel. Instead, it should be distributed as a
Python-3-only wheel.