### PR TITLE
Py3 cleanup: Remove unnecessary __ne__ method

### DIFF
--- a/examples/btpyparse.py
+++ b/examples/btpyparse.py
@@ -22,8 +22,6 @@ class Macro(object):
         return 'Macro("%s")' % self.name
     def __eq__(self, other):
         return self.name == other.name
-    def __ne__(self, other):
-        return self.name != other.name
 
 
 # Character literals

--- a/pyparsing.py
+++ b/pyparsing.py
@@ -2385,9 +2385,6 @@ class ParserElement(object):
             return vars(self) == vars(other)
         return False
 
-    def __ne__(self, other):
-        return not (self == other)
-
     def __hash__(self):
         return id(self)
 


### PR DESCRIPTION
Unlink Python 2, in Python 3, `__ne__` defaults to the inverse of the
`__eq__` method. Can remove the definitions that follow this default.

From the Python docs
https://docs.python.org/3/reference/datamodel.html#object.__ne__

> By default, `__ne__()` delegates to `__eq__()` and inverts the result
> unless it is NotImplemented.