### PR TITLE
Py3 cleanup: Remove workaround for Python2 urllib

### DIFF
--- a/examples/getNTPserversNew.py
+++ b/examples/getNTPserversNew.py
@@ -8,13 +8,7 @@
 #
 import pyparsing as pp
 ppc = pp.pyparsing_common
-
-try:
-    import urllib.request
-    urlopen = urllib.request.urlopen
-except ImportError:
-    import urllib
-    urlopen = urllib.urlopen
+from urllib.request import urlopen
 
 integer = pp.Word(pp.nums)
 ipAddress = ppc.ipv4_address()

--- a/examples/statemachine/statemachine.py
+++ b/examples/statemachine/statemachine.py
@@ -8,14 +8,7 @@ import sys
 import os
 import types
 import importlib
-try:
-    import urllib.parse
-    url_parse = urllib.parse.urlparse
-except ImportError:
-    print("import error, Python 2 not supported")
-    raise
-    import urllib
-    url_parse = urllib.parse
+from urllib.parse import urlparse
 
 
 DEBUG = False
@@ -271,7 +264,7 @@ class SuffixImporter(object):
         sys.path.append(cls.trigger_url())
 
     def __init__(self, path_entry):
-        pr = url_parse(str(path_entry))
+        pr = urlparse(str(path_entry))
         if pr.scheme != self.scheme or pr.path != self.suffix:
             raise ImportError()
         self.path_entry = path_entry


### PR DESCRIPTION
For Python 3 only code, the import path is known and stable. Can remove
the ImportError workaround.