### PR TITLE
Fix tox to run refactored tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install codecov
 
 script:
- - python -m unittest discover tests
+ - python -m unittest
 
 after_success:
   - codecov run -m unittest tests.test_unit

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,4 @@ envlist=py{35,36,37,38,py3}
 [testenv]
 deps=coverage
 commands=
-    coverage run --parallel --branch tests/test_simple_unit.py
-    coverage run --parallel --branch tests/test_unit.py
+    coverage run --parallel --branch -m unittest


### PR DESCRIPTION
After commit 3481b6f3f9bb2dae7e9d88ed08989b5f71238e4b, tox failed to run
tests locally. The tox configuration now uses a command identical to
Travis. It runs the unittest test discoverer.

The command "discover" is the default if no additional argument is
passed to unittest.