### PR TITLE
Explicitly specify UTF-8 encoding when opening README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 ============
 
 The pyparsing module is an alternative approach to creating and
-executing simple grammars, vs. the traditional lex/yacc approach, or the
+executing simple grammars, vs. the traditional lex/yacc approach, or the
 use of regular expressions. The pyparsing module provides a library of
 classes that client code uses to construct the grammar directly in
 Python code.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pyparsing import __version__ as pyparsing_version
 README_name = __file__.replace("setup.py", "README.rst")
 
 # The text of the README file
-with open(README_name) as README:
+with open(README_name, encoding='utf8') as README:
     pyparsing_main_doc = README.read()
 
 modules = ["pyparsing",]

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 
 from setuptools import setup
 from pyparsing import __version__ as pyparsing_version
+from io import open
 
 # The directory containing this file
 README_name = __file__.replace("setup.py", "README.rst")


### PR DESCRIPTION
Hello,

On environments where the default encoding is set to ASCII (i.e. default Debian Stretch), installing pyparsing 2.4.4 fails with an error because README.rst contains a unicode character.
Explicitly specifying the encoding as UTF-8 fixes the problem.