### PR TITLE
Smedberg/various minor fixes

### DIFF
--- a/examples/bigquery_view_parser.py
+++ b/examples/bigquery_view_parser.py
@@ -317,7 +317,7 @@ class BigQueryViewParser:
         collation_name = identifier.copy()
         # NOTE: Column names can be keywords.  Doc says they cannot, but in practice it seems to work.
         column_name = identifier_word.copy()
-        qualified_column_name = Combine(column_name + ("." + column_name) * (0, 6))
+        qualified_column_name = Combine(column_name + (ZeroOrMore(" ") + "." + ZeroOrMore(" ") + column_name) * (0, 6))
         # NOTE: As with column names, column aliases can be keywords, e.g. functions like `current_time`.  Other
         # keywords, e.g. `from` make parsing pretty difficult (e.g. "SELECT a from from b" is confusing.)
         column_alias = ~keyword_nonfunctions + column_name.copy()
@@ -1578,6 +1578,16 @@ class BigQueryViewParser:
             """,
             [(None, None, "z")],
         ],
+
+        [
+            """
+            SELECT a . b .   c
+            FROM d
+            """,
+            [
+                (None, None, 'd')
+            ]
+        ]
     ]
 
     def test(self):


### PR DESCRIPTION
Various fixes to sample of parsing BigQuery SQL definition:

1. Failed parsing column specifications that include whitespace, like `tablename. columnname`
2. Failed parsing `UNION` that contains `WITH` statement
3. Previous `UNION` fix introduced a bug with parsing `SELECT`s that are surrounded with parenthesis
4. Table identifiers that are partially quoted and partially unquoted weren't properly handled, e.g. ``` `edw-prod-153420`.pdw.mrr_to_instance_mapping```