### PR TITLE
Add Black formatting Git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
-      line_length: 90
+      line_length: 80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/python/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.5
+      

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,4 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
+      max-line-length: 90

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
-      line_length: 80
+      line_length: 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
-      max-line-length: 90
+      line_length: 90

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,4 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.5
-      
+      language_version: python3.6

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -702,7 +702,7 @@ def infixNotation(baseExpr, opList, lpar=Suppress("("), rpar=Suppress(")")):
                     "operator must be unary (1), binary (2), or ternary (3)"
                 )
         elif rightLeftAssoc == opAssoc.RIGHT:
-            if arity == 1:
+            if arity == 1 :
                 # try to avoid LR with this extra test
                 if not isinstance(opExpr, Optional):
                     opExpr = Optional(opExpr)

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -702,7 +702,7 @@ def infixNotation(baseExpr, opList, lpar=Suppress("("), rpar=Suppress(")")):
                     "operator must be unary (1), binary (2), or ternary (3)"
                 )
         elif rightLeftAssoc == opAssoc.RIGHT:
-            if arity == 1 :
+            if arity == 1:
                 # try to avoid LR with this extra test
                 if not isinstance(opExpr, Optional):
                     opExpr = Optional(opExpr)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+## Development
+     
+After forking the pyparsing repo, and cloning your fork locally, install the libraries needed to run tests
+
+     pip install -r tests/requirements.txt
+         
+Run the tests to ensure your envirmnet is setup 
+     
+     python -m unittest discover tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,7 @@
 After forking the pyparsing repo, and cloning your fork locally, install the libraries needed to run tests
 
      pip install -r tests/requirements.txt
+     pre-commit install
          
 Run the tests to ensure your envirmnet is setup 
      

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,6 +5,6 @@ After forking the pyparsing repo, and cloning your fork locally, install the lib
      pip install -r tests/requirements.txt
      pre-commit install
          
-Run the tests to ensure your envirmnet is setup 
+Run the tests to ensure your environment is setup 
      
      python -m unittest discover tests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 coverage==4.4.2
 tox==3.5.2
+pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands=
 
 [testenv:black]
 deps = black
-commands = {envbindir}/black --target-version py35 --line-length 90 --check --diff .
+commands = {envbindir}/black --target-version py35 --line-length 80 --check --diff .

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands=
 
 [testenv:black]
 deps = black
-commands = {envbindir}/black --target-version py35 --check --diff .
+commands = {envbindir}/black --target-version py35 --max-line-length 90 --check --diff .

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands=
 
 [testenv:black]
 deps = black
-commands = {envbindir}/black --target-version py35 --max-line-length 90 --check --diff .
+commands = {envbindir}/black --target-version py35 --line-length 90 --check --diff .

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands=
 
 [testenv:black]
 deps = black
-commands = {envbindir}/black --target-version py35 --line-length 80 --check --diff .
+commands = {envbindir}/black --target-version py35 --line-length 88 --check --diff .


### PR DESCRIPTION
This hook will run Black upon commit.  If something needs formatting, then the file is fixed, and the commit fails.  Commit a second time for success.  This only acts on changed files.