### PR TITLE
Add / operator overload

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1166,6 +1166,18 @@ class ParserElement:
     def __rmul__(self, other):
         return self.__mul__(other)
 
+    def __truediv__(self, other):
+        """
+        Implementation of / operator - applies parse action to a copy.
+        """
+        return self.copy().addParseAction(other)
+
+    def __itruediv__(self, other):
+        """
+        Implementation of /= operator - applies parse action to self.
+        """
+        return self.addParseAction(other)
+
     def __or__(self, other):
         """
         Implementation of | operator - returns :class:`MatchFirst`

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -401,6 +401,12 @@ class TestParseAction(PyparsingExpressionTestCase):
             text="0A4B7321FE76",
             expected_list=["0A", "21", "4B", "73", "76", "FE"],
         ),
+        PpTestSpec(
+            desc="Using / as addParseAction",
+            expr=pp.Word("0123456789") / (lambda t: int(t[0])),
+            text="12345",
+            expected_list=[12345],
+        ),
     ]
 
 


### PR DESCRIPTION
This adds / and /= as equivalent to .copy().addParseAction() and .addParseAction() respectively.

Coming from [LPeg](http://www.inf.puc-rio.br/~roberto/lpeg/lpeg.html), I find that having an operator for addParseAction makes code cleaner and clearer. For example, currently I have this:

```python
    skippable = Optional("?", default="")

    escape_char = Literal("%")
    any_char = CharsNotIn("", exact=1)
    str_token = Literal("'")
    re_token = Literal("/")

    unexpected_token = any_char.copy().setParseAction(_err_tok)
    unexpected_end = StringEnd().setParseAction(_err_tok)

    unexpected_str_escape = any_char.copy().setParseAction(_err_str_esc)
    str_escape = Suppress(escape_char) + (str_token | escape_char)
    str_escape |= escape_char + unexpected_str_escape
    str_char = (str_escape | CharsNotIn("%'"))

    str_literal = (Combine(Suppress(str_token) + str_char[...]
                           + (Suppress(str_token)
                              | StringEnd().setParseAction(_err_str_end)))
                   + skippable)
    str_literal.setParseAction(lambda toks: [_vm.StringKey(toks)])

    unexpected_re_escape = any_char.copy().setParseAction(_err_re_esc)
    re_escape = Suppress(escape_char) + (re_token | escape_char)
    re_escape |= escape_char + unexpected_re_escape
    re_char = (re_escape | CharsNotIn("%/"))

    re_literal = (Combine(Suppress(re_token) + re_char[...]
                          + (Suppress(re_token)
                             | StringEnd().setParseAction(_err_re_end)))
                  + skippable)
    re_literal.setParseAction(lambda toks: [_vm.RegexKey(toks)])

    # [more stuff omitted]
```

and with this change it becomes:

```python
    skippable = Optional("?", default="")

    escape_char = Literal("%")
    any_char = CharsNotIn("", exact=1)
    str_token = Literal("'")
    re_token = Literal("/")

    unexpected_token = any_char / _err_tok
    unexpected_end = StringEnd() / _err_tok

    unexpected_str_escape = any_char / _err_str_esc
    str_escape = Suppress(escape_char) + (str_token | escape_char)
    str_escape |= escape_char + unexpected_str_escape
    str_char = (str_escape | CharsNotIn("%'"))

    str_literal = (Combine(Suppress(str_token) + str_char[...]
                           + (Suppress(str_token)
                              | StringEnd() / _err_str_end))
                   + skippable) / (lambda toks: [_vm.StringKey(toks)])

    unexpected_re_escape = any_char / _err_re_esc
    re_escape = Suppress(escape_char) + (re_token | escape_char)
    re_escape |= escape_char + unexpected_re_escape
    re_char = (re_escape | CharsNotIn("%/"))

    re_literal = (Combine(Suppress(re_token) + re_char[...]
                          + (Suppress(re_token)
                             | StringEnd() / _err_re_end))
                  + skippable) / (lambda toks: [_vm.RegexKey(toks)])

    # [more stuff omitted]
```

which I find more manageable than the other one. (I use setParseAction/addParseAction a lot. altho I should probably be using addParseAction where I currently use setParseAction but oh well.)