### PR TITLE
Don't import unittest in testing.py

### DIFF
--- a/pyparsing/testing.py
+++ b/pyparsing/testing.py
@@ -1,7 +1,6 @@
 # testing.py
 
 from contextlib import contextmanager
-import unittest
 
 from pyparsing.core import (
     ParserElement,


### PR DESCRIPTION
This import is currently unused in the file.

I'm looking at optimising start-up times of a project I work on, and
importing pyparsing currently takes about 82ms, which is quite a lot for
my domain. Just not importing `unittest` shaves 14ms off of that import
time.

Currently 

Before this change:
```
$ multitime -n 20 --  python3.6 -c 'import pyparsing'
===> multitime results
1: python3.6 -c "import pyparsing"
            Mean        Std.Dev.    Min         Median      Max
real        0.082       0.005       0.071       0.083       0.088
user        0.066       0.004       0.056       0.067       0.071
sys         0.013       0.001       0.012       0.013       0.014
```

After this change:
```
$ multitime -n 20 --  python3.6 -c 'import pyparsing'

===> multitime results
1: python3.6 -c "import pyparsing"
            Mean        Std.Dev.    Min         Median      Max
real        0.068       0.005       0.060       0.068       0.083
user        0.053       0.004       0.047       0.054       0.066
sys         0.011       0.001       0.010       0.011       0.013
```

I may come back soon with a few other optimisation-style changes, but this one seemed like pretty easy low-hanging fruit, unless there's a big reason to do this importing I'm not seeing :)