### PR TITLE
Parser Element and Keyword tests

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2444,6 +2444,119 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         ):
             result = expr.parseString("spam eggs")
 
+    def testParserElementMulOperatorWithTuples(self):
+        """test ParserElement "*" with various tuples"""
+
+        # ParserElement * (0, 0)
+        with self.assertRaises(
+            ValueError, msg="ParserElement * (0,0) should raise error"
+        ):
+            expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * (0, 0)
+
+        # ParserElement * (None, n)
+        expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * (None, 3)
+
+        results1 = expr.parseString("spam")
+        print(results1.dump())
+        expected = ["spam"]
+        self.assertParseResultsEquals(
+            results1, expected, msg="issue with ParserElement optional matches"
+        )
+
+        results2 = expr.parseString("spam 12 23 34")
+        print(results2.dump())
+        expected = ["spam", "12", "23", "34"]
+        self.assertParseResultsEquals(
+            results2, expected, msg="issue with ParserElement optional matches"
+        )
+
+        # ParserElement * (1, 1)
+        expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * (1, 1)
+
+        results1 = expr.parseString("spam 45")
+        print(results1.dump())
+        expected = ["spam", "45"]
+        self.assertParseResultsEquals(
+            results1, expected, msg="issue with ParserElement optional matches"
+        )
+
+        # ParserElement * (1, greater)
+        expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * (1, 3)
+
+        results1 = expr.parseString("spam 100")
+        print(results1.dump())
+        expected = ["spam", "100"]
+        self.assertParseResultsEquals(
+            results1, expected, msg="issue with ParserElement optional matches"
+        )
+
+        results2 = expr.parseString("spam 100 200 300")
+        print(results2.dump())
+        expected = ["spam", "100", "200", "300"]
+        self.assertParseResultsEquals(
+            results2, expected, msg="issue with ParserElement optional matches"
+        )
+
+        # ParserElement * (lesser, greater)
+        expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * (2, 3)
+
+        results1 = expr.parseString("spam 1 2")
+        print(results1.dump())
+        expected = ["spam", "1", "2"]
+        self.assertParseResultsEquals(
+            results1, expected, msg="issue with ParserElement optional matches"
+        )
+
+        results2 = expr.parseString("spam 1 2 3")
+        print(results2.dump())
+        expected = ["spam", "1", "2", "3"]
+        self.assertParseResultsEquals(
+            results2, expected, msg="issue with ParserElement optional matches"
+        )
+
+        # ParserElement * (greater, lesser)
+        with self.assertRaises(
+            ValueError, msg="ParserElement * (0,0) should raise error"
+        ):
+            expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second") * (3, 2)
+
+        # ParserElement * (str, str)
+        with self.assertRaises(
+            TypeError, msg="ParserElement * (0,0) should raise error"
+        ):
+            expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second") * ("2", "3")
+
+    def testParserElementMulOperatorWithOtherTypes(self):
+        """test the overridden "*" operator with other data types"""
+
+        # ParserElement * str
+        with self.assertRaises(TypeError, msg="ParserElement * str should raise error"):
+            expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second") * "3"
+
+        # str * ParserElement
+        with self.assertRaises(TypeError, msg="str * ParserElement should raise error"):
+            expr = pp.Word(pp.alphas)("first") + "3" * pp.Word(pp.nums)("second")
+
+        # ParserElement * int
+        expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * 2
+
+        results = expr.parseString("spam 11 22")
+        print(results.dump())
+        expected = ["spam", "11", "22"]
+        self.assertParseResultsEquals(
+            results, expected, msg="issue with ParserElement optional matches"
+        )
+
+        # int * ParserElement
+        expr = pp.Word(pp.alphas)("first") + 2 * pp.Word(pp.nums)("second*")
+
+        results = expr.parseString("spam 111 222")
+        print(results.dump())
+        expected = ["spam", "111", "222"]
+        self.assertParseResultsEquals(
+            results, expected, msg="issue with ParserElement optional matches"
+        )
+
     def testParseResultsNewEdgeCases(self):
         """test less common paths of ParseResults.__new__()"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2370,6 +2370,43 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             "got {!r}".format(res.Achar),
         )
 
+    def testParserElementAddOperatorWithOtherTypes(self):
+        """test the overridden "+" operator with other data types"""
+
+        # ParserElement + str
+        expr = pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second") + "suf"
+        result = expr.parseString("spam eggs suf")
+        print(result)
+        expected = ["spam", "eggs", "suf"]
+        self.assertParseResultsEquals(
+            result, expected, msg="issue adding str to ParserElement"
+        )
+
+        # str + ParserElement
+        expr = "pre" + pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second")
+        result = expr.parseString("pre spam eggs")
+        print(result)
+        expected = ["pre", "spam", "eggs"]
+        self.assertParseResultsEquals(
+            result, expected, msg="issue adding str to ParserElement"
+        )
+
+        # ParserElement + int
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement + int"):
+            expr = pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second") + 12
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
+        # int + ParserElement
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement + int"):
+            expr = 12 + pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second")
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
     def testParseResultsNewEdgeCases(self):
         """test less common paths of ParseResults.__new__()"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2576,6 +2576,47 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         ):
             result = expr.parseString("spam eggs")
 
+    def testParserElementMatchLongestWithOtherTypes(self):
+        """test the overridden "^" operator with other data types"""
+
+        # ParserElement ^ str
+        expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") ^ "suf")
+        result = expr.parseString("spam eggs")
+        print(result)
+        expected = {"first": "spam", "second": "eggs"}
+        self.assertParseResultsEquals(
+            result, expected_dict=expected, msg="issue with ParserElement ^ str"
+        )
+
+        # str ^ ParserElement
+        expr = ("pre" ^ pp.Word("pr")("first")) + pp.Word(pp.alphas)("second")
+        result = expr.parseString("pre eggs")
+        print(result)
+        expected_l = ["pre", "eggs"]
+        expected_d = {"second": "eggs"}
+        self.assertParseResultsEquals(
+            result,
+            expected_list=expected_l,
+            expected_dict=expected_d,
+            msg="issue with str ^ ParserElement",
+        )
+
+        # ParserElement ^ int
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement ^ int"):
+            expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") ^ 54)
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
+        # int ^ ParserElement
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement ^ int"):
+            expr = pp.Word(pp.alphas)("first") + (65 ^ pp.Word(pp.alphas)("second"))
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
     def testParseResultsNewEdgeCases(self):
         """test less common paths of ParseResults.__new__()"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2617,6 +2617,44 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         ):
             result = expr.parseString("spam eggs")
 
+    def testParserElementEachOperatorWithOtherTypes(self):
+        """test the overridden "&" operator with other data types"""
+
+        # ParserElement & str
+        expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") & "and")
+        with self.assertRaisesParseException():
+            result = expr.parseString("spam and eggs")
+
+        # str & ParserElement
+        expr = pp.Word(pp.alphas)("first") + ("and" & pp.Word(pp.alphas)("second"))
+        result = expr.parseString("spam and eggs")
+
+        print(result.dump())
+        expected_l = ["spam", "and", "eggs"]
+        expected_d = {"first": "spam", "second": "eggs"}
+        self.assertParseResultsEquals(
+            result,
+            expected_list=expected_l,
+            expected_dict=expected_d,
+            msg="issue with str & ParserElement",
+        )
+
+        # ParserElement & int
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement & int"):
+            expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas) & 78)
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
+        # int & ParserElement
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement & int"):
+            expr = pp.Word(pp.alphas)("first") + (89 & pp.Word(pp.alphas))
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
     def testParseResultsNewEdgeCases(self):
         """test less common paths of ParseResults.__new__()"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2407,6 +2407,43 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         ):
             result = expr.parseString("spam eggs")
 
+    def testParserElementSubOperatorWithOtherTypes(self):
+        """test the overridden "-" operator with other data types"""
+
+        # ParserElement - str
+        expr = pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second") - "suf"
+        result = expr.parseString("spam eggs suf")
+        print(result)
+        expected = ["spam", "eggs", "suf"]
+        self.assertParseResultsEquals(
+            result, expected, msg="issue with ParserElement - str"
+        )
+
+        # str - ParserElement
+        expr = "pre" - pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second")
+        result = expr.parseString("pre spam eggs")
+        print(result)
+        expected = ["pre", "spam", "eggs"]
+        self.assertParseResultsEquals(
+            result, expected, msg="issue with str - ParserElement"
+        )
+
+        # ParserElement - int
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement - int"):
+            expr = pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second") - 12
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
+        # int - ParserElement
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement - int"):
+            expr = 12 - pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second")
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
     def testParseResultsNewEdgeCases(self):
         """test less common paths of ParseResults.__new__()"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2377,35 +2377,31 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         expr = pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second") + "suf"
         result = expr.parseString("spam eggs suf")
         print(result)
-        expected = ["spam", "eggs", "suf"]
+
+        expected_l = ["spam", "eggs", "suf"]
         self.assertParseResultsEquals(
-            result, expected, msg="issue adding str to ParserElement"
+            result, expected_l, msg="issue with ParserElement + str",
         )
 
         # str + ParserElement
         expr = "pre" + pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second")
         result = expr.parseString("pre spam eggs")
         print(result)
-        expected = ["pre", "spam", "eggs"]
+
+        expected_l = ["pre", "spam", "eggs"]
         self.assertParseResultsEquals(
-            result, expected, msg="issue adding str to ParserElement"
+            result, expected_l, msg="issue with str + ParserElement",
         )
 
         # ParserElement + int
         with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement + int"):
             expr = pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second") + 12
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
         # int + ParserElement
-        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement + int"):
+        with self.assertWarns(SyntaxWarning, msg="failed to warn int + ParserElement"):
             expr = 12 + pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second")
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
     def testParserElementSubOperatorWithOtherTypes(self):
         """test the overridden "-" operator with other data types"""
@@ -2431,18 +2427,12 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         # ParserElement - int
         with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement - int"):
             expr = pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second") - 12
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
         # int - ParserElement
-        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement - int"):
+        with self.assertWarns(SyntaxWarning, msg="failed to warn int - ParserElement"):
             expr = 12 - pp.Word(pp.alphas)("first") + pp.Word(pp.alphas)("second")
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
     def testParserElementMulOperatorWithTuples(self):
         """test ParserElement "*" with various tuples"""
@@ -2460,41 +2450,41 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         print(results1.dump())
         expected = ["spam"]
         self.assertParseResultsEquals(
-            results1, expected, msg="issue with ParserElement optional matches"
+            results1, expected, msg="issue with ParserElement * w/ optional matches"
         )
 
         results2 = expr.parseString("spam 12 23 34")
         print(results2.dump())
         expected = ["spam", "12", "23", "34"]
         self.assertParseResultsEquals(
-            results2, expected, msg="issue with ParserElement optional matches"
+            results2, expected, msg="issue with ParserElement * w/ optional matches"
         )
 
         # ParserElement * (1, 1)
         expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * (1, 1)
+        results = expr.parseString("spam 45")
+        print(results.dump())
 
-        results1 = expr.parseString("spam 45")
-        print(results1.dump())
         expected = ["spam", "45"]
         self.assertParseResultsEquals(
-            results1, expected, msg="issue with ParserElement optional matches"
+            results, expected, msg="issue with ParserElement * (1, 1)"
         )
 
-        # ParserElement * (1, greater)
+        # ParserElement * (1, 1+n)
         expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * (1, 3)
 
         results1 = expr.parseString("spam 100")
         print(results1.dump())
         expected = ["spam", "100"]
         self.assertParseResultsEquals(
-            results1, expected, msg="issue with ParserElement optional matches"
+            results1, expected, msg="issue with ParserElement * (1, 1+n)"
         )
 
         results2 = expr.parseString("spam 100 200 300")
         print(results2.dump())
         expected = ["spam", "100", "200", "300"]
         self.assertParseResultsEquals(
-            results2, expected, msg="issue with ParserElement optional matches"
+            results2, expected, msg="issue with ParserElement * (1, 1+n)"
         )
 
         # ParserElement * (lesser, greater)
@@ -2504,25 +2494,25 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         print(results1.dump())
         expected = ["spam", "1", "2"]
         self.assertParseResultsEquals(
-            results1, expected, msg="issue with ParserElement optional matches"
+            results1, expected, msg="issue with ParserElement * (lesser, greater)"
         )
 
         results2 = expr.parseString("spam 1 2 3")
         print(results2.dump())
         expected = ["spam", "1", "2", "3"]
         self.assertParseResultsEquals(
-            results2, expected, msg="issue with ParserElement optional matches"
+            results2, expected, msg="issue with ParserElement * (lesser, greater)"
         )
 
         # ParserElement * (greater, lesser)
         with self.assertRaises(
-            ValueError, msg="ParserElement * (0,0) should raise error"
+            ValueError, msg="ParserElement * (greater, lesser) should raise error"
         ):
             expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second") * (3, 2)
 
         # ParserElement * (str, str)
         with self.assertRaises(
-            TypeError, msg="ParserElement * (0,0) should raise error"
+            TypeError, msg="ParserElement * (str, str) should raise error"
         ):
             expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second") * ("2", "3")
 
@@ -2539,22 +2529,22 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
         # ParserElement * int
         expr = pp.Word(pp.alphas)("first") + pp.Word(pp.nums)("second*") * 2
-
         results = expr.parseString("spam 11 22")
+
         print(results.dump())
         expected = ["spam", "11", "22"]
         self.assertParseResultsEquals(
-            results, expected, msg="issue with ParserElement optional matches"
+            results, expected, msg="issue with ParserElement * int"
         )
 
         # int * ParserElement
         expr = pp.Word(pp.alphas)("first") + 2 * pp.Word(pp.nums)("second*")
-
         results = expr.parseString("spam 111 222")
+
         print(results.dump())
         expected = ["spam", "111", "222"]
         self.assertParseResultsEquals(
-            results, expected, msg="issue with ParserElement optional matches"
+            results, expected, msg="issue with int * ParserElement"
         )
 
     def testParserElementMatchFirstOperatorWithOtherTypes(self):
@@ -2563,66 +2553,52 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         # ParserElement | int
         with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement | int"):
             expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") | 12)
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
         # int | ParserElement
-        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement | int"):
+        with self.assertWarns(SyntaxWarning, msg="failed to warn int | ParserElement"):
             expr = pp.Word(pp.alphas)("first") + (12 | pp.Word(pp.alphas)("second"))
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
     def testParserElementMatchLongestWithOtherTypes(self):
         """test the overridden "^" operator with other data types"""
 
         # ParserElement ^ str
-        expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") ^ "suf")
+        expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.nums)("second") ^ "eggs")
         result = expr.parseString("spam eggs")
         print(result)
-        expected = {"first": "spam", "second": "eggs"}
+
+        expected = ["spam", "eggs"]
         self.assertParseResultsEquals(
-            result, expected_dict=expected, msg="issue with ParserElement ^ str"
+            result, expected, msg="issue with ParserElement ^ str"
         )
 
         # str ^ ParserElement
         expr = ("pre" ^ pp.Word("pr")("first")) + pp.Word(pp.alphas)("second")
         result = expr.parseString("pre eggs")
         print(result)
-        expected_l = ["pre", "eggs"]
-        expected_d = {"second": "eggs"}
+
+        expected = ["pre", "eggs"]
         self.assertParseResultsEquals(
-            result,
-            expected_list=expected_l,
-            expected_dict=expected_d,
-            msg="issue with str ^ ParserElement",
+            result, expected, msg="issue with str ^ ParserElement",
         )
 
         # ParserElement ^ int
         with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement ^ int"):
             expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") ^ 54)
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
         # int ^ ParserElement
-        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement ^ int"):
+        with self.assertWarns(SyntaxWarning, msg="failed to warn int ^ ParserElement"):
             expr = pp.Word(pp.alphas)("first") + (65 ^ pp.Word(pp.alphas)("second"))
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
     def testParserElementEachOperatorWithOtherTypes(self):
         """test the overridden "&" operator with other data types"""
 
         # ParserElement & str
         expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") & "and")
-        with self.assertRaisesParseException():
+        with self.assertRaisesParseException(msg="issue with ParserElement & str"):
             result = expr.parseString("spam and eggs")
 
         # str & ParserElement
@@ -2642,18 +2618,12 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         # ParserElement & int
         with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement & int"):
             expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas) & 78)
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
         # int & ParserElement
-        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement & int"):
+        with self.assertWarns(SyntaxWarning, msg="failed to warn int & ParserElement"):
             expr = pp.Word(pp.alphas)("first") + (89 & pp.Word(pp.alphas))
-        with self.assertRaises(
-            AttributeError, msg="parsing None type should raise error"
-        ):
-            result = expr.parseString("spam eggs")
+        self.assertEqual(expr, None)
 
     def testParseResultsNewEdgeCases(self):
         """test less common paths of ParseResults.__new__()"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1247,10 +1247,9 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             )
 
     def testParseKeyword(self):
-        from pyparsing import Literal, Keyword
 
-        kw = Keyword("if")
-        lit = Literal("if")
+        kw = pp.Keyword("if")
+        lit = pp.Literal("if")
 
         def test(s, litShouldPass, kwShouldPass):
             print("Test", s)
@@ -1280,11 +1279,16 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         test("if(OnlyIfOnly)", True, True)
         test("if (OnlyIf Only)", True, True)
 
-        kw = Keyword("if", caseless=True)
+        kw = pp.Keyword("if", caseless=True)
 
         test("IFOnlyIfOnly", False, False)
         test("If(OnlyIfOnly)", False, True)
         test("iF (OnlyIf Only)", False, True)
+
+        with self.assertWarns(
+            SyntaxWarning, msg="failed to warn empty string passed to Keyword"
+        ):
+            kw = pp.Keyword("")
 
     def testParseExpressionResultsAccumulate(self):
         from pyparsing import Word, delimitedList, Combine, alphas, nums

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2557,6 +2557,25 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             results, expected, msg="issue with ParserElement optional matches"
         )
 
+    def testParserElementMatchFirstOperatorWithOtherTypes(self):
+        """test the overridden "|" operator with other data types"""
+
+        # ParserElement | int
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement | int"):
+            expr = pp.Word(pp.alphas)("first") + (pp.Word(pp.alphas)("second") | 12)
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
+        # int | ParserElement
+        with self.assertWarns(SyntaxWarning, msg="failed to warn ParserElement | int"):
+            expr = pp.Word(pp.alphas)("first") + (12 | pp.Word(pp.alphas)("second"))
+        with self.assertRaises(
+            AttributeError, msg="parsing None type should raise error"
+        ):
+            result = expr.parseString("spam eggs")
+
     def testParseResultsNewEdgeCases(self):
         """test less common paths of ParseResults.__new__()"""
 


### PR DESCRIPTION
These tests focus on previously uncovered paths. Two behaviors surprised me, though these are edge cases:

1. When a type other than ParserElement or string is used in any of the expressions (I use int as a test case) a warning is issued and the entire expr is set to None. This will later throw a ParseError when the expr is parsed because a None type can't be parsed.
2. When using type string with the & operator, it seems that can be parsed successfully provided they are in the order of the string being parsed, but not if they're out of order.

Both of these may be expected behavior, just thought I'd share.