### PR TITLE
Pop counter token and return rest instead of dropping all tokens in countedArray

### DIFF
--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -55,7 +55,7 @@ def countedArray(expr, intExpr=None):
 
     def countFieldParseAction(s, l, t):
         n = t[0]
-        arrayExpr << And([expr] * n) if n else empty
+        arrayExpr << (And([expr] * n) if n else empty)
         # clear list contents, but keep any named results
         del t[:]
 

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -54,9 +54,9 @@ def countedArray(expr, intExpr=None):
     arrayExpr = Forward()
 
     def countFieldParseAction(s, l, t):
-        n = t[0]
+        n = t.pop(0)
         arrayExpr << (n and Group(And([expr] * n)) or Group(empty))
-        return []
+        return t
 
     if intExpr is None:
         intExpr = Word(nums).setParseAction(lambda t: int(t[0]))

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -55,7 +55,7 @@ def countedArray(expr, intExpr=None):
 
     def countFieldParseAction(s, l, t):
         n = t[0]
-        arrayExpr << (n and Group(And([expr] * n)) or Group(empty))
+        arrayExpr << And([expr] * n) if n else empty
         # clear list contents, but keep any named results
         del t[:]
 

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -54,9 +54,10 @@ def countedArray(expr, intExpr=None):
     arrayExpr = Forward()
 
     def countFieldParseAction(s, l, t):
-        n = t.pop(0)
+        n = t[0]
         arrayExpr << (n and Group(And([expr] * n)) or Group(empty))
-        return t
+        # clear list contents, but keep any named results
+        del t[:]
 
     if intExpr is None:
         intExpr = Word(nums).setParseAction(lambda t: int(t[0]))

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -503,7 +503,7 @@ class TestCommonHelperExpressions(PyparsingExpressionTestCase):
         ),
         PpTestSpec(
             desc="A counted array of words",
-            expr=pp.countedArray(pp.Word("ab"))[...],
+            expr=pp.Group(pp.countedArray(pp.Word("ab")))[...],
             text="2 aaa bbb 0 3 abab bbaa abbab",
             expected_list=[["aaa", "bbb"], [], ["abab", "bbaa", "abbab"]],
         ),

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2963,14 +2963,14 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             print("got maximum excursion limit exception")
 
     def testCountedArray(self):
-        from pyparsing import Word, nums, OneOrMore, countedArray
+        from pyparsing import Word, nums, OneOrMore, Group, countedArray
 
         testString = "2 5 7 6 0 1 2 3 4 5 0 3 5 4 3"
 
         integer = Word(nums).setParseAction(lambda t: int(t[0]))
         countedField = countedArray(integer)
 
-        r = OneOrMore(countedField).parseString(testString)
+        r = OneOrMore(Group(countedField)).parseString(testString)
         print(testString)
         print(r)
 
@@ -2980,7 +2980,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
     # addresses bug raised by Ralf Vosseler
     def testCountedArrayTest2(self):
-        from pyparsing import Word, nums, OneOrMore, countedArray
+        from pyparsing import Word, nums, OneOrMore, Group, countedArray
 
         testString = "2 5 7 6 0 1 2 3 4 5 0 3 5 4 3"
 
@@ -2988,7 +2988,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         countedField = countedArray(integer)
 
         dummy = Word("A")
-        r = OneOrMore(dummy ^ countedField).parseString(testString)
+        r = OneOrMore(Group(dummy ^ countedField)).parseString(testString)
         print(testString)
         print(r)
 
@@ -2997,7 +2997,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         )
 
     def testCountedArrayTest3(self):
-        from pyparsing import Word, nums, OneOrMore, countedArray, alphas
+        from pyparsing import Word, nums, OneOrMore, Group, countedArray, alphas
 
         int_chars = "_" + alphas
         array_counter = Word(int_chars).setParseAction(lambda t: int_chars.index(t[0]))
@@ -3008,7 +3008,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         integer = Word(nums).setParseAction(lambda t: int(t[0]))
         countedField = countedArray(integer, intExpr=array_counter)
 
-        r = OneOrMore(countedField).parseString(testString)
+        r = OneOrMore(Group(countedField)).parseString(testString)
         print(testString)
         print(r)
 


### PR DESCRIPTION
A really small change but a quite useful one.
The `countedArray` helper is very nice but it assumes that the count expression is directly preceding the list. I've stumbled upon a situation where there are some extra tokens in between the count token and items in the list.

Example: There are two flags right after the count value which describe the list in some way. They can take a single ascii letter or "-".
With my change, one can do:

```python
my_array = countedArray(Word(alphanums), And([
    Word(nums).setParseAction(lambda t: int(t[0])),
    Group(Char(alphas + "-") * 2)
]))

print(my_array.parseString("5 a b item1 item2 item3 item4 item5"))
```
which will print:
```python
[['a', 'b'], ['item1', 'item2', 'item3', 'item4', 'item5']]
```

This doesn't change a normal behaviour of `countedArray` where there's no `intExpr` provided or it returns only a single token.