### PR TITLE
examples -- romanNumerals -- makeRomanNumeral bug fix, added MMMMM test

### DIFF
--- a/examples/romanNumerals.py
+++ b/examples/romanNumerals.py
@@ -45,7 +45,7 @@ romanNumeral = numeral[1, ...].setParseAction(sum)
 # unit tests
 def makeRomanNumeral(n):
     def addDigits(n, limit, c, s):
-        while n > limit:
+        while n >= limit:
             n -= limit
             s += c
         return n, s
@@ -95,6 +95,7 @@ romanNumeral.runTests(
     XIX
     MCMLXXX
     MMVI
+    MMMMM
     """,
     fullDump=False,
     postParse=verify_value,


### PR DESCRIPTION
There was a bug in the makeRomanNumerals function in romanNumerals.py.  For example, makeRomanNumeral(2) would return 'I', and makeRomanNumeral(3) would return 'II', etc.  This was tracked to an issue within that function that was fixed.  Adding the test for 'MMMMM' caused a test failure with the previous code and now it works.  The 'MMMMM' test was added to the set of tests.