### PR TITLE
Additional configuration for `skipWhitespace` and `leaveWhitespace`

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1343,6 +1343,14 @@ class ParserElement:
         """
         return Suppress(self)
 
+    def ignoreWhitespace(self):
+        """
+        Enables the skipping of whitespace before matching the characters in the
+        :class:`ParserElement`'s defined pattern.
+        """
+        self.skipWhitespace = True
+        return self
+
     def leaveWhitespace(self):
         """
         Disables the skipping of whitespace before matching the characters in the

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1343,19 +1343,23 @@ class ParserElement:
         """
         return Suppress(self)
 
-    def ignoreWhitespace(self):
+    def ignoreWhitespace(self, recursive=True):
         """
         Enables the skipping of whitespace before matching the characters in the
         :class:`ParserElement`'s defined pattern.
+
+        :param recursive: If true (the default), also enable whitespace skipping in child elements (if any)
         """
         self.skipWhitespace = True
         return self
 
-    def leaveWhitespace(self):
+    def leaveWhitespace(self, recursive=True):
         """
         Disables the skipping of whitespace before matching the characters in the
         :class:`ParserElement`'s defined pattern.  This is normally only used internally by
         the pyparsing module, but may be needed in some whitespace-sensitive grammars.
+
+        :param recursive: If true (the default), also disable whitespace skipping in child elements (if any)
         """
         self.skipWhitespace = False
         return self
@@ -3003,13 +3007,26 @@ class ParseExpression(ParserElement):
         self.strRepr = None
         return self
 
-    def leaveWhitespace(self):
-        """Extends ``leaveWhitespace`` defined in base class, and also invokes ``leaveWhitespace`` on
-           all contained expressions."""
-        self.skipWhitespace = False
+    def leaveWhitespace(self, recursive=True):
+        """
+        Extends ``leaveWhitespace`` defined in base class, and also invokes ``leaveWhitespace`` on
+           all contained expressions.
+        """
+        super().leaveWhitespace(recursive)
         self.exprs = [e.copy() for e in self.exprs]
         for e in self.exprs:
-            e.leaveWhitespace()
+            e.leaveWhitespace(recursive)
+        return self
+
+    def ignoreWhitespace(self, recursive=True):
+        """
+        Extends ``ignoreWhitespace`` defined in base class, and also invokes ``leaveWhitespace`` on
+           all contained expressions.
+        """
+        super().ignoreWhitespace(recursive)
+        self.exprs = [e.copy() for e in self.exprs]
+        for e in self.exprs:
+            e.ignoreWhitespace(recursive)
         return self
 
     def ignore(self, other):
@@ -3680,11 +3697,20 @@ class ParseElementEnhance(ParserElement):
         else:
             raise ParseException("", loc, self.errmsg, self)
 
-    def leaveWhitespace(self):
-        self.skipWhitespace = False
+    def leaveWhitespace(self, recursive=True):
+        super().leaveWhitespace(recursive)
+
         self.expr = self.expr.copy()
         if self.expr is not None:
-            self.expr.leaveWhitespace()
+            self.expr.leaveWhitespace(recursive)
+        return self
+
+    def ignoreWhitespace(self, recursive=True):
+        super().ignoreWhitespace(recursive)
+
+        self.expr = self.expr.copy()
+        if self.expr is not None:
+            self.expr.ignoreWhitespace(recursive)
         return self
 
     def ignore(self, other):
@@ -4291,8 +4317,12 @@ class Forward(ParseElementEnhance):
         ret = super().__or__(other)
         return ret
 
-    def leaveWhitespace(self):
+    def leaveWhitespace(self, recursive=True):
         self.skipWhitespace = False
+        return self
+
+    def ignoreWhitespace(self, recursive=True):
+        self.skipWhitespace = True
         return self
 
     def streamline(self):

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3013,9 +3013,11 @@ class ParseExpression(ParserElement):
            all contained expressions.
         """
         super().leaveWhitespace(recursive)
-        self.exprs = [e.copy() for e in self.exprs]
-        for e in self.exprs:
-            e.leaveWhitespace(recursive)
+
+        if recursive:
+            self.exprs = [e.copy() for e in self.exprs]
+            for e in self.exprs:
+                e.leaveWhitespace(recursive)
         return self
 
     def ignoreWhitespace(self, recursive=True):
@@ -3024,9 +3026,10 @@ class ParseExpression(ParserElement):
            all contained expressions.
         """
         super().ignoreWhitespace(recursive)
-        self.exprs = [e.copy() for e in self.exprs]
-        for e in self.exprs:
-            e.ignoreWhitespace(recursive)
+        if recursive:
+            self.exprs = [e.copy() for e in self.exprs]
+            for e in self.exprs:
+                e.ignoreWhitespace(recursive)
         return self
 
     def ignore(self, other):
@@ -3700,17 +3703,19 @@ class ParseElementEnhance(ParserElement):
     def leaveWhitespace(self, recursive=True):
         super().leaveWhitespace(recursive)
 
-        self.expr = self.expr.copy()
-        if self.expr is not None:
-            self.expr.leaveWhitespace(recursive)
+        if recursive:
+            self.expr = self.expr.copy()
+            if self.expr is not None:
+                self.expr.leaveWhitespace(recursive)
         return self
 
     def ignoreWhitespace(self, recursive=True):
         super().ignoreWhitespace(recursive)
 
-        self.expr = self.expr.copy()
-        if self.expr is not None:
-            self.expr.ignoreWhitespace(recursive)
+        if recursive:
+            self.expr = self.expr.copy()
+            if self.expr is not None:
+                self.expr.ignoreWhitespace(recursive)
         return self
 
     def ignore(self, other):

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -597,7 +597,7 @@ class TestWhitespaceMethods(PyparsingExpressionTestCase):
         ),
         # These test the composite elements
         PpTestSpec(
-            desc="If we leave whitespace on the parent, this whitespace-dependent grammar will succeed, even if the children themselves skip whitespace",
+            desc="If we recursively leave whitespace on the parent, this whitespace-dependent grammar will succeed, even if the children themselves skip whitespace",
             expr=pp.And(
                 [
                     pp.Literal(" foo").ignoreWhitespace(),
@@ -609,7 +609,7 @@ class TestWhitespaceMethods(PyparsingExpressionTestCase):
         ),
         #
         PpTestSpec(
-            desc="If we ignore whitespace in our parsing, this whitespace-dependent grammar will fail, even if the children themselves keep whitespace",
+            desc="If we recursively ignore whitespace in our parsing, this whitespace-dependent grammar will fail, even if the children themselves keep whitespace",
             expr=pp.And(
                 [
                     pp.Literal(" foo").leaveWhitespace(),
@@ -619,9 +619,20 @@ class TestWhitespaceMethods(PyparsingExpressionTestCase):
             text=" foo bar",
             expected_fail_locn=1,
         ),
+        PpTestSpec(
+            desc="If we leave whitespace on the parent, but it isn't recursive, this whitespace-dependent grammar will fail",
+            expr=pp.And(
+                [
+                    pp.Literal(" foo").ignoreWhitespace(),
+                    pp.Literal(" bar").ignoreWhitespace(),
+                ]
+            ).leaveWhitespace(recursive=False),
+            text=" foo bar",
+            expected_fail_locn=5,
+        ),
         # These test the Enhance classes
         PpTestSpec(
-            desc="If we leave whitespace on the parent, this whitespace-dependent grammar will succeed, even if the children themselves skip whitespace",
+            desc="If we recursively leave whitespace on the parent, this whitespace-dependent grammar will succeed, even if the children themselves skip whitespace",
             expr=pp.Optional(pp.Literal(" foo").ignoreWhitespace()).leaveWhitespace(
                 recursive=True
             ),
@@ -630,13 +641,21 @@ class TestWhitespaceMethods(PyparsingExpressionTestCase):
         ),
         #
         PpTestSpec(
-            desc="If we ignore whitespace in our parsing, this whitespace-dependent grammar will fail, even if the children themselves keep whitespace",
+            desc="If we ignore whitespace on the parent, but it isn't recursive, parsing will fail because we skip to the first character 'f' before the internal expr can see it",
             expr=pp.Optional(pp.Literal(" foo").leaveWhitespace()).ignoreWhitespace(
                 recursive=True
             ),
             text=" foo",
             expected_list=[],
         ),
+        # PpTestSpec(
+        #     desc="If we leave whitespace on the parent, this whitespace-dependent grammar will succeed, even if the children themselves skip whitespace",
+        #     expr=pp.Optional(pp.Literal(" foo").ignoreWhitespace()).leaveWhitespace(
+        #         recursive=False
+        #     ),
+        #     text=" foo",
+        #     expected_list=[]
+        # ),
     ]
 
 

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -570,6 +570,7 @@ class TestCommonHelperExpressions(PyparsingExpressionTestCase):
 
 class TestWhitespaceMethods(PyparsingExpressionTestCase):
     tests = [
+        # These test the single-element versions
         PpTestSpec(
             desc="The word foo",
             expr=pp.Literal("foo").ignoreWhitespace(),
@@ -593,6 +594,48 @@ class TestWhitespaceMethods(PyparsingExpressionTestCase):
             expr=pp.Literal("foo").leaveWhitespace(),
             text="foo",
             expected_list=["foo"],
+        ),
+        # These test the composite elements
+        PpTestSpec(
+            desc="If we leave whitespace on the parent, this whitespace-dependent grammar will succeed, even if the children themselves skip whitespace",
+            expr=pp.And(
+                [
+                    pp.Literal(" foo").ignoreWhitespace(),
+                    pp.Literal(" bar").ignoreWhitespace(),
+                ]
+            ).leaveWhitespace(recursive=True),
+            text=" foo bar",
+            expected_list=[" foo", " bar"],
+        ),
+        #
+        PpTestSpec(
+            desc="If we ignore whitespace in our parsing, this whitespace-dependent grammar will fail, even if the children themselves keep whitespace",
+            expr=pp.And(
+                [
+                    pp.Literal(" foo").leaveWhitespace(),
+                    pp.Literal(" bar").leaveWhitespace(),
+                ]
+            ).ignoreWhitespace(recursive=True),
+            text=" foo bar",
+            expected_fail_locn=1,
+        ),
+        # These test the Enhance classes
+        PpTestSpec(
+            desc="If we leave whitespace on the parent, this whitespace-dependent grammar will succeed, even if the children themselves skip whitespace",
+            expr=pp.Optional(pp.Literal(" foo").ignoreWhitespace()).leaveWhitespace(
+                recursive=True
+            ),
+            text=" foo",
+            expected_list=[" foo"],
+        ),
+        #
+        PpTestSpec(
+            desc="If we ignore whitespace in our parsing, this whitespace-dependent grammar will fail, even if the children themselves keep whitespace",
+            expr=pp.Optional(pp.Literal(" foo").leaveWhitespace()).ignoreWhitespace(
+                recursive=True
+            ),
+            text=" foo",
+            expected_list=[],
         ),
     ]
 

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -568,6 +568,35 @@ class TestCommonHelperExpressions(PyparsingExpressionTestCase):
     ]
 
 
+class TestWhitespaceMethods(PyparsingExpressionTestCase):
+    tests = [
+        PpTestSpec(
+            desc="The word foo",
+            expr=pp.Literal("foo").ignoreWhitespace(),
+            text="      foo        ",
+            expected_list=["foo"],
+        ),
+        PpTestSpec(
+            desc="The word foo",
+            expr=pp.Literal("foo").leaveWhitespace(),
+            text="      foo        ",
+            expected_fail_locn=0,
+        ),
+        PpTestSpec(
+            desc="The word foo",
+            expr=pp.Literal("foo").ignoreWhitespace(),
+            text="foo",
+            expected_list=["foo"],
+        ),
+        PpTestSpec(
+            desc="The word foo",
+            expr=pp.Literal("foo").leaveWhitespace(),
+            text="foo",
+            expected_list=["foo"],
+        ),
+    ]
+
+
 def _get_decl_line_no(cls):
     import inspect
 


### PR DESCRIPTION
* Add the `ignoreWhitespace()` method, which is the opposite of `leaveWhitespace()` (it sets `skipWhitespace=True`
* Add the argument `recursive=True` to both the above methods, to allow you to control which elements this affects

This closes #203 and helps with some other annoying issues I've been facing.