### PR TITLE
Fixing generated default name for QuotedString

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -2602,7 +2602,7 @@ class QuotedString(Token):
         self.mayReturnEmpty = True
 
     def _generateDefaultName(self):
-        return "quoted string, starting with %s ending with {}".format(
+        return "quoted string, starting with {} ending with {}".format(
             self.quoteChar, self.endQuoteChar,
         )
 


### PR DESCRIPTION
Looks like an issue in changing the type of string format used