### PR TITLE
Remove identChars override from Keyword.copy

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1992,7 +1992,6 @@ class Keyword(Token):
 
     def copy(self):
         c = super().copy()
-        c.identChars = Keyword.DEFAULT_KEYWORD_CHARS
         return c
 
     @staticmethod

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5983,6 +5983,11 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                     False, "failed to match keyword using updated keyword chars"
                 )
 
+    def testKeywordCopyIdentChars(self):
+        a_keyword = pp.Keyword("start", identChars="_")
+        b_keyword = a_keyword.copy()
+        self.assertEqual(a_keyword.identChars, b_keyword.identChars)
+
     def testLiteralVsKeyword(self):
 
         integer = ppc.integer


### PR DESCRIPTION
The current behaviour of Keyword.copy unintuitively overrides the identChars of the copied keyword back to the DEFAULT_KEYWORD_CHARS. 

As such:
`
a_keyword = pp.Keyword("test", identChars="_") 
b_keyword = a_keyword.copy() 
`
Match different patterns.

This appears to be either a mistake, or is undocumented.
This pull request removes that override and adds a test to verify.