### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: pypy3
       env: TOXENV=pypy3
   fast_finish: true

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(  # Distribution meta-data
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38,py3}
+    py{35,36,37,38,39,py3}
 
 [testenv]
 deps=coverage


### PR DESCRIPTION
`py39-dev` has been removed in 5811c79597aa718df2e72fb95189233055a2ded3, now the final Python 3.9 version can be used.