### PR TITLE
Fix misc. documentation typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -566,7 +566,7 @@ the upcoming 2.4.2:
 
 - API change adding support for `expr[...]` - the original
   code in 2.4.1 incorrectly implemented this as OneOrMore.
-  Code using this feature under this relase should explicitly
+  Code using this feature under this release should explicitly
   use `expr[0, ...]` for ZeroOrMore and `expr[1, ...]` for
   OneOrMore. In 2.4.2 you will be able to write `expr[...]`
   equivalent to `ZeroOrMore(expr)`.
@@ -712,9 +712,9 @@ Version 2.4.1 - July, 2019
      - warn_ungrouped_named_tokens_in_collection - flag to enable warnings when a results
        name is defined on a containing expression with ungrouped subexpressions that also
        have results names (default=True)
-     - warn_name_set_on_empty_Forward - flag to enable warnings whan a Forward is defined
+     - warn_name_set_on_empty_Forward - flag to enable warnings when a Forward is defined
        with a results name, but has no contents defined (default=False)
-     - warn_on_multiple_string_args_to_oneof - flag to enable warnings whan oneOf is
+     - warn_on_multiple_string_args_to_oneof - flag to enable warnings when oneOf is
        incorrectly called with multiple str arguments (default=True)
      - enable_debug_on_named_expressions - flag to auto-enable debug on all subsequent
        calls to ParserElement.setName() (default=False)
@@ -1402,7 +1402,7 @@ Version 2.1.6 - August, 2016
   repr form provides important information when debugging parse actions.
 
 
-Verison 2.1.5 - June, 2016
+Version 2.1.5 - June, 2016
 ------------------------------
 - Added ParserElement.split() generator method, similar to re.split().
   Includes optional arguments maxsplit (to limit the number of splits),
@@ -1725,7 +1725,7 @@ Version 2.0.2 - April, 2014
 - Added "pprint()" method to ParseResults, to simplify troubleshooting
   and prettified output. Now instead of importing the pprint module
   and then writing "pprint.pprint(result)", you can just write
-  "result.pprint()".  This method also accepts addtional positional and
+  "result.pprint()".  This method also accepts additional positional and
   keyword arguments (such as indent, width, etc.), which get passed
   through directly to the pprint method
   (see https://docs.python.org/2/library/pprint.html#pprint.pprint).
@@ -1857,7 +1857,7 @@ Version 1.5.7 - November, 2012
 
 - Fixed bug in srange when using '\x###' hex character codes.
 
-- Addeed optional 'intExpr' argument to countedArray, so that you
+- Added optional 'intExpr' argument to countedArray, so that you
   can define your own expression that will evaluate to an integer,
   to be used as the count for the following elements. Allows you
   to define a countedArray with the count given in hex, for example,
@@ -2532,7 +2532,7 @@ Version 1.4.6 - April, 2007
   programs, at some cost to performance (3-5%). Suggested by bca48150 on
   the pyparsing wiki, thanks!
 
-- Enhanced the documentation describing the vagaries and idiosyncracies
+- Enhanced the documentation describing the vagaries and idiosyncrasies
   of parsing strings with embedded tabs, and the impact on:
   . parse actions
   . scanString

--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -651,7 +651,7 @@ Expression operators
 - ``*`` - creates ``And`` by multiplying the expression by the integer operand; if
   expression is multiplied by a 2-tuple, creates an ``And`` of (min,max)
   expressions (similar to "{min,max}" form in regular expressions); if
-  min is None, intepret as (0,max); if max is None, interpret as
+  min is None, interpret as (0,max); if max is None, interpret as
   ``expr*min + ZeroOrMore(expr)``
 
 - ``-`` - like ``+`` but with no backup and retry of alternatives
@@ -895,7 +895,7 @@ Helper methods
       to the ``infixNotation`` method.
 
   2.  Define a list of tuples for each level of operator
-      precendence.  Each tuple is of the form
+      precedence.  Each tuple is of the form
       ``(opExpr, numTerms, rightLeftAssoc, parseAction)``, where:
 
       - ``opExpr`` - the pyparsing expression for the operator;

--- a/docs/whats_new_in_3_0_0.rst
+++ b/docs/whats_new_in_3_0_0.rst
@@ -112,7 +112,7 @@ the docs for ``locaatedExpr`` show this output::
         [[18, 'lkkjj', 23]]
 
 The parsed values and the start and end locations are merged into a single
-nested ParseResults (and any results names inthe parsed values are also
+nested ParseResults (and any results names in the parsed values are also
 merged in with the start and end location names).
 
 Using ``Located``, the output is::

--- a/examples/AcManForm.dfm
+++ b/examples/AcManForm.dfm
@@ -511,7 +511,7 @@ object Form1: TForm1
     object SearchFindFirst1: TSearchFindFirst
       Category = 'Search'
       Caption = 'F&ind First'
-      Hint = 'Find First|Finds the first occurance of specified text'
+      Hint = 'Find First|Finds the first occurrence of specified text'
     end
     object CustomizeActionBars1: TCustomizeActionBars
       Category = 'Tools'

--- a/examples/booleansearchparser.py
+++ b/examples/booleansearchparser.py
@@ -11,7 +11,7 @@ It handles:
 * parentheses;
 * quoted strings;
 * wildcards at the end of a search term (help*);
-* wildcards at the begining of a search term (*lp);
+* wildcards at the beginning of a search term (*lp);
 * non-western languages
 
 Requirements:
@@ -22,7 +22,7 @@ SAMPLE USAGE:
 from booleansearchparser import BooleanSearchParser
 from __future__ import print_function
 bsp = BooleanSearchParser()
-text = u"wildcards at the begining of a search term "
+text = u"wildcards at the beginning of a search term "
 exprs= [
     u"*cards and term", #True
     u"wild* and term",  #True
@@ -139,7 +139,7 @@ class BooleanSearchParser:
 
         Grammar:
         - a query consists of alphanumeric words, with an optional '*'
-          wildcard at the end or the begining of a word
+          wildcard at the end or the beginning of a word
         - a sequence of words between quotes is a literal string
         - words can be used together by using operators ('and' or 'or')
         - words with operators can be grouped with parenthesis
@@ -151,7 +151,7 @@ class BooleanSearchParser:
 
         alphabet = alphanums
 
-        # suport for non-western alphabets
+        # support for non-western alphabets
         for r in alphabet_ranges:
             alphabet += "".join(chr(c) for c in range(*r) if not chr(c).isspace())
 
@@ -315,7 +315,7 @@ class BooleanSearchParser:
 
 class ParserTest(BooleanSearchParser):
     """Tests the parser with some search queries
-    tests containts a dictionary with tests and expected results.
+    tests contains a dictionary with tests and expected results.
     """
 
     def Test(self):

--- a/examples/lucene_grammar.py
+++ b/examples/lucene_grammar.py
@@ -3,7 +3,7 @@
 #
 # Copyright 2011, Paul McGuire
 #
-# implementation of Lucene grammar, as decribed
+# implementation of Lucene grammar, as described
 # at http://svn.apache.org/viewvc/lucene/dev/trunk/lucene/docs/queryparsersyntax.html
 #
 

--- a/examples/pymicko.py
+++ b/examples/pymicko.py
@@ -49,7 +49,7 @@ DEBUG = 0
 # %14 is the stack frame pointer (x86's ebp) and %15 is the stack pointer (x86's esp). All data-handling instructions can be
 # unsigned (suffix U), or signed (suffix S). These are ADD, SUB, MUL and DIV. These are three-address instructions,
 # the first two operands are input, the third one is output. Whether these operands are registers, memory or constant
-# is not relevant, all combinations are possible (except that output cannot be a constant). Constants are writen with a $ prefix (10-base only).
+# is not relevant, all combinations are possible (except that output cannot be a constant). Constants are written with a $ prefix (10-base only).
 # Conditional jumps are handled by JXXY instructions, where XX is LT, GT, LE, GE, EQ, NE (less than, greater than, less than or equal, etc.)
 # and Y is U or S (unsigned or signed, except for JEQ i JNE). Unconditional jump is JMP. The move instruction is MOV.
 # Function handling is done using CALL, RET, PUSH and POP (C style function calls). Static data is defined using the WORD directive
@@ -264,7 +264,7 @@ class ExceptionSharedData:
         self.text = ""
 
     def setpos(self, location, text):
-        """Helper function for setting curently parsed text and position"""
+        """Helper function for setting currently parsed text and position"""
         self.location = location
         self.text = text
 
@@ -364,7 +364,7 @@ class SymbolTable:
 
     def error(self, text=""):
         """Symbol table error exception. It should happen only if index is out of range while accessing symbol table.
-           This exeption is not handled by the compiler, so as to allow traceback printing
+           This exception is not handled by the compiler, so as to allow traceback printing
         """
         if text == "":
             raise Exception("Symbol table index out of range")
@@ -440,7 +440,7 @@ class SymbolTable:
         return self.table_len - 1
 
     def clear_symbols(self, index):
-        """Clears all symbols begining with the index to the end of table"""
+        """Clears all symbols beginning with the index to the end of table"""
         try:
             del self.table[index:]
         except Exception:
@@ -453,10 +453,10 @@ class SymbolTable:
         skind=list(SharedData.KINDS.keys()),
         stype=list(SharedData.TYPES.keys()),
     ):
-        """Searches for symbol, from the end to the begining.
+        """Searches for symbol, from the end to the beginning.
            Returns symbol index or None
            sname - symbol name
-           skind - symbol kind (one kind, list of kinds, or None) deafult: any kind
+           skind - symbol kind (one kind, list of kinds, or None) default: any kind
            stype - symbol type (or None) default: any type
         """
         skind = skind if isinstance(skind, list) else [skind]
@@ -471,7 +471,7 @@ class SymbolTable:
 
     def insert_id(self, sname, skind, skinds, stype):
         """Inserts a new identifier at the end of the symbol table, if possible.
-           Returns symbol index, or raises an exception if the symbol alredy exists
+           Returns symbol index, or raises an exception if the symbol already exists
            sname   - symbol name
            skind   - symbol kind
            skinds  - symbol kinds to check for
@@ -681,7 +681,7 @@ class CodeGenerator:
 
     def error(self, text):
         """Compiler error exception. It should happen only if something is wrong with compiler.
-           This exeption is not handled by the compiler, so as to allow traceback printing
+           This exception is not handled by the compiler, so as to allow traceback printing
         """
         raise Exception("Compiler error: %s" % text)
 
@@ -1132,7 +1132,7 @@ class MicroC:
         self.function_arguments = []
         # stack for arguments of the nested function calls
         self.function_arguments_stack = []
-        # number of arguments for the curent function call
+        # number of arguments for the current function call
         self.function_arguments_number = -1
         # stack for the number of arguments for the nested function calls
         self.function_arguments_number_stack = []

--- a/examples/pythonGrammarParser.py
+++ b/examples/pythonGrammarParser.py
@@ -15,7 +15,7 @@ grammar = r"""
 # Note:  Changing the grammar specified in this file will most likely
 #        require corresponding changes in the parser module
 #        (../Modules/parsermodule.c).  If you can't make the changes to
-#        that module yourself, please co-ordinate the required changes
+#        that module yourself, please coordinate the required changes
 #        with someone who can; ask around on python-dev for help.  Fred
 #        Drake <fdrake@acm.org> will probably be listening there.
 

--- a/examples/searchparser.py
+++ b/examples/searchparser.py
@@ -206,7 +206,7 @@ class SearchQueryParser:
 
 class ParserTest(SearchQueryParser):
     """Tests the parser with some search queries
-    tests containts a dictionary with tests and expected results.
+    tests contains a dictionary with tests and expected results.
     """
 
     tests = {

--- a/examples/simpleArith.py
+++ b/examples/simpleArith.py
@@ -30,7 +30,7 @@ factop = Literal("!")
 #       and integer or a variable.  This will be the first argument
 #       to the infixNotation method.
 #   2.  Define a list of tuples for each level of operator
-#       precendence.  Each tuple is of the form
+#       precedence.  Each tuple is of the form
 #       (opExpr, numTerms, rightLeftAssoc, parseAction), where
 #       - opExpr is the pyparsing expression for the operator;
 #          may also be a string, which will be converted to a Literal

--- a/examples/snmp_api.h
+++ b/examples/snmp_api.h
@@ -458,7 +458,7 @@ int snmp_close_sessions (void);
  * of outstanding requests on this session, then send the pdu.
  * Returns the request id of the generated packet if applicable, otherwise 1.
  * On any error, 0 is returned.
- * The pdu is freed by snmp_send() unless a failure occured.
+ * The pdu is freed by snmp_send() unless a failure occurred.
  */
 int snmp_send (struct snmp_session *, struct snmp_pdu *);
 
@@ -476,7 +476,7 @@ int snmp_send (struct snmp_session *, struct snmp_pdu *);
  * then send the pdu.
  * Returns the request id of the generated packet if applicable, otherwise 1.
  * On any error, 0 is returned.
- * The pdu is freed by snmp_send() unless a failure occured.
+ * The pdu is freed by snmp_send() unless a failure occurred.
  */
 int snmp_async_send (struct snmp_session *, struct snmp_pdu *,
                          snmp_callback, void *);
@@ -646,7 +646,7 @@ struct snmp_session *snmp_open_ex (struct snmp_session *,
   int (*fcheck) (u_char *, size_t)
 );
 
-/* provided for backwards compatability.  Don't use these functions.
+/* provided for backwards compatibility.  Don't use these functions.
    See snmp_debug.h and snmp_debug.c instead.
 */
 #if HAVE_STDARG_H

--- a/pyparsing/diagram/__init__.py
+++ b/pyparsing/diagram/__init__.py
@@ -164,7 +164,7 @@ class ElementState:
         self.parent_index = index  # type: Optional[int]
         #: If true, we should extract this out into a subdiagram
         self.extract = False  # type: bool
-        #: If true, all of this element's chilren have been filled out
+        #: If true, all of this element's children have been filled out
         self.complete = False  # type: bool
 
     def mark_for_extraction(

--- a/pyparsing_archive.py
+++ b/pyparsing_archive.py
@@ -179,9 +179,9 @@ class __diag__(__config_flags):
      - warn_ungrouped_named_tokens_in_collection - flag to enable warnings when a results
        name is defined on a containing expression with ungrouped subexpressions that also
        have results names
-     - warn_name_set_on_empty_Forward - flag to enable warnings whan a Forward is defined
+     - warn_name_set_on_empty_Forward - flag to enable warnings when a Forward is defined
        with a results name, but has no contents defined
-     - warn_on_multiple_string_args_to_oneof - flag to enable warnings whan oneOf is
+     - warn_on_multiple_string_args_to_oneof - flag to enable warnings when oneOf is
        incorrectly called with multiple str arguments
      - enable_debug_on_named_expressions - flag to auto-enable debug on all subsequent
        calls to ParserElement.setName()

--- a/tests/json_parser_tests.py
+++ b/tests/json_parser_tests.py
@@ -103,7 +103,7 @@ test4 = """
         /*
             New! useJSP switches on JSP template processing.
             jspListTemplate and jspFileTemplate are the names
-            of the default templates to look for when aquiring JSP
+            of the default templates to look for when acquiring JSP
             templates.  Cofax currently in production at KR has useJSP
             set to false, since our sites currently use WYSIWYG
             templating exclusively.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6811,7 +6811,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
     def testWarnNameSetOnEmptyForward(self):
         """
-         - warn_name_set_on_empty_Forward - flag to enable warnings whan a Forward is defined
+         - warn_name_set_on_empty_Forward - flag to enable warnings when a Forward is defined
            with a results name, but has no contents defined (default=False)
         """
 
@@ -6828,7 +6828,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
     def testWarnParsingEmptyForward(self):
         """
-         - warn_on_parse_using_empty_Forward - flag to enable warnings whan a Forward
+         - warn_on_parse_using_empty_Forward - flag to enable warnings when a Forward
            has no contents defined (default=False)
         """
 
@@ -6848,7 +6848,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
     def testWarnIncorrectAssignmentToForward(self):
         """
-         - warn_on_parse_using_empty_Forward - flag to enable warnings whan a Forward
+         - warn_on_parse_using_empty_Forward - flag to enable warnings when a Forward
            has no contents defined (default=False)
         """
         if PYPY_ENV:
@@ -6870,7 +6870,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
     def testWarnOnMultipleStringArgsToOneOf(self):
         """
-         - warn_on_multiple_string_args_to_oneof - flag to enable warnings whan oneOf is
+         - warn_on_multiple_string_args_to_oneof - flag to enable warnings when oneOf is
            incorrectly called with multiple str arguments (default=True)
         """
 


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,fourty,halp,inout,strng`