### PR TITLE
add a caseless parameter to the CloseMatch class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,6 +56,9 @@ Version 3.0.0c1 -
 - Fixed bug in QuotedString class when the escaped quote string is not a
   repeated character. (Issue #263)
 
+- Added a caseless parameter to the `CloseMatch` class to allow for casing to be ignored when checking for close matches
+
+
 
 Version 3.0.0b3 - August, 2021
 ------------------------------

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -2380,6 +2380,7 @@ class CloseMatch(Token):
     :class:`CloseMatch` takes parameters:
 
      - ``match_string`` - string to be matched
+     - ``caseless`` - a boolean indicating whether to ignore casing when comparing characters
      - ``max_mismatches`` - (``default=1``) maximum number of
        mismatches allowed to count as a match
 
@@ -2409,7 +2410,7 @@ class CloseMatch(Token):
     """
 
     def __init__(
-        self, match_string: str, max_mismatches: int = None, *, maxMismatches: int = 1
+        self, match_string: str, max_mismatches: int = None, *, maxMismatches: int = 1, caseless=False
     ):
         maxMismatches = max_mismatches if max_mismatches is not None else maxMismatches
         super().__init__()
@@ -2418,6 +2419,7 @@ class CloseMatch(Token):
         self.errmsg = "Expected {!r} (with up to {} mismatches)".format(
             self.match_string, self.maxMismatches
         )
+        self.caseless = caseless
         self.mayIndexError = False
         self.mayReturnEmpty = False
 
@@ -2439,6 +2441,9 @@ class CloseMatch(Token):
                 zip(instring[loc:maxloc], match_string)
             ):
                 src, mat = s_m
+                if self.caseless:
+                    src, mat = src.lower(), mat.lower()
+
                 if src != mat:
                     mismatches.append(match_stringloc)
                     if len(mismatches) > maxMismatches:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5857,6 +5857,38 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                 else ("no match", "match")[r[1].mismatches == exp],
             )
 
+    def testCloseMatchCaseless(self):
+
+        searchseq = pp.CloseMatch("ATCATCGAATGGA", 2, caseless=True)
+
+        _, results = searchseq.runTests(
+            """
+            atcatcgaatgga
+            xtcatcgaatggx
+            atcatcgaaxgga
+            atcaxxgaatgga
+            atcaxxgaatgxa
+            atcaxxgaatgg
+            """
+        )
+        expected = ([], [0, 12], [9], [4, 5], None, None)
+
+        for r, exp in zip(results, expected):
+            if exp is not None:
+                self.assertEqual(
+                    exp,
+                    r[1].mismatches,
+                    "fail CaselessCloseMatch between {!r} and {!r}".format(
+                        searchseq.match_string, r[0]
+                    ),
+                )
+            print(
+                r[0],
+                "exc: %s" % r[1]
+                if exp is None and isinstance(r[1], Exception)
+                else ("no match", "match")[r[1].mismatches == exp],
+            )
+
     def testDefaultKeywordChars(self):
 
         with self.assertRaisesParseException(


### PR DESCRIPTION
fixes #279 

in addition to unit tests, this change also includes formatting changes to unrelated code that the pre-commit hook required me to do before committing.

My machine says that tests are failing, however it seems to be due to tests that are unrelated to the new changes or new tests that I have added. These tests were failing when i ran the commands to set up the testing environment as suggested in the `tests/README` file and i'm not sure how to properly deal with them since this is my first contribution to this codebase