### PR TITLE
Left-Recursion support

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4463,8 +4463,6 @@ class Forward(ParseElementEnhance):
                         new_loc, new_result = prev_loc, prev_result
                     # the match did not get better: we are done
                     if new_loc == prev_loc:
-                        if isinstance(prev_result, Exception):
-                            raise prev_result
                         return new_loc, new_result
                     elif new_loc < prev_loc:
                         return prev_loc, prev_result

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4425,10 +4425,6 @@ class Forward(ParseElementEnhance):
             )
         if not ParserElement._bounded_recursion_enabled:
             return super().parseImpl(instring, loc, doActions)
-        else:
-            return self.parse_recursive(instring, loc, doActions)
-
-    def parse_recursive(self, instring, loc, doActions=True):
         with ParserElement.recursion_lock:
             memo = ParserElement.recursion_memos.setdefault(loc, {})
             # there are two cases for the current `self` clause in the memo:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -773,10 +773,10 @@ class ParserElement(ABC):
         ParserElement.recursion_memos.clear()
 
     _packratEnabled = False
-    _bounded_recursion_enabled = False
+    _left_recursion_enabled = False
 
     @staticmethod
-    def enable_bounded_recursion():
+    def enable_left_recursion():
         """
         Enables "bounded recursion" parsing, which allows for both direct and indirect
         left-recursion. During parsing, left-recursive :class:`Forward` elements are
@@ -786,7 +786,7 @@ class ParserElement(ABC):
         Example::
 
             import pyparsing as pp
-            pp.ParserElement.enable_bounded_recursion()
+            pp.ParserElement.enable_left_recursion()
 
             E = pp.Forward("E")
             num = pp.Word(pp.nums)
@@ -804,7 +804,7 @@ class ParserElement(ABC):
         """
         if ParserElement._packratEnabled:
             raise RuntimeError("Packrat and Bounded Recursion are not compatible")
-        ParserElement._bounded_recursion_enabled = True
+        ParserElement._left_recursion_enabled = True
 
     @staticmethod
     def enablePackrat(cache_size_limit=128):
@@ -833,7 +833,7 @@ class ParserElement(ABC):
                import pyparsing
                pyparsing.ParserElement.enablePackrat()
         """
-        if ParserElement._bounded_recursion_enabled:
+        if ParserElement._left_recursion_enabled:
             raise RuntimeError("Packrat and Bounded Recursion are not compatible")
         if not ParserElement._packratEnabled:
             ParserElement._packratEnabled = True
@@ -4429,7 +4429,7 @@ class Forward(ParseElementEnhance):
                 "Forward expression was never assigned a value, will not parse any input",
                 stacklevel=stacklevel,
             )
-        if not ParserElement._bounded_recursion_enabled:
+        if not ParserElement._left_recursion_enabled:
             return super().parseImpl(instring, loc, doActions)
         # ## Bounded Recursion algorithm ##
         # Recursion only needs to be processed at ``Forward`` elements, since they are

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4463,14 +4463,10 @@ class Forward(ParseElementEnhance):
                 return prev_loc, prev_result.copy()
             except KeyError:
                 # we are searching for the best result – keep on improving
-                prev_loc, prev_result = memo[key] = loc, ParseException(
+                prev_loc, prev_result = memo[key] = loc - 1, ParseException(
                     instring, loc, "Forward recursion without base case", self
                 )
                 while True:
-                    # Note:
-                    # Medeiros et al. settles on the *previous* result when there is
-                    # no improvement. Since we can have viable zero-length content
-                    # (due to parse actions) we use the *newest* result if possible.
                     try:
                         new_loc, new_result = super().parseImpl(instring, loc, doActions)
                     except ParseException:
@@ -4479,9 +4475,7 @@ class Forward(ParseElementEnhance):
                             raise
                         new_loc, new_result = prev_loc, prev_result
                     # the match did not get better: we are done
-                    if new_loc == prev_loc:
-                        return new_loc, new_result
-                    elif new_loc < prev_loc:
+                    if new_loc <= prev_loc:
                         return prev_loc, prev_result
                     # the match did get better: see if we can improve further
                     else:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4417,7 +4417,6 @@ class Forward(ParseElementEnhance):
                     instring, loc, "Forward recursion without base case", self
                 )
                 while True:
-                    print('match', self, loc, prev_loc, prev_result)
                     # Note:
                     # Medeiros et al. settles on the *previous* result when there is
                     # no improvement. Since we can have viable zero-length content

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4482,11 +4482,11 @@ class Forward(ParseElementEnhance):
                         return prev_loc, prev_peek.copy()
                     # the match did get better: see if we can improve further
                     else:
-                        prev_loc, prev_peek = memo[self, False] = new_loc, new_peek
                         if doActions:
                             # TODO: store errors
-                            # TODO: fail on backtrack (we go out of sync otherwise)
+                            # TODO: fail on backtrack? (we go out of sync otherwise)
                             memo[self, True] = super().parseImpl(instring, loc, True)
+                        prev_loc, prev_peek = memo[self, False] = new_loc, new_peek
 
 
 

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -779,7 +779,9 @@ class ParserElement(ABC):
     def enable_bounded_recursion():
         """
         Enables "bounded recursion" parsing, which allows for both direct and indirect
-        left-recursion.
+        left-recursion. During parsing, left-recursive :class:`Forward` elements are
+        repeatedly matched with a fixed recursion depth that is gradually increased
+        until finding the longest match.
 
         Example::
 
@@ -792,9 +794,13 @@ class ParserElement(ABC):
 
             print(E.parseString("1+2+3"))
 
+        Searching the ideal recursion depth requires matching elements at least one
+        additional time. In addition, recusion search naturally memoizes matches and
+        may thus skip evaluation during backtracking. This may break existing programs
+        with parse actions which rely on side-effects.
 
-        Bounded Recursion parsing works similar but not identical to Packrat parsing,
-        thus the two cannot be used together.
+        Bounded Recursion parsing works similar but not identical to Packrat parsing.
+        Thus the two cannot be used together.
         """
         if ParserElement._packratEnabled:
             raise RuntimeError("Packrat and Bounded Recursion are not compatible")

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -827,6 +827,8 @@ class ParserElement(ABC):
                import pyparsing
                pyparsing.ParserElement.enablePackrat()
         """
+        if ParserElement._bounded_recursion_enabled:
+            raise RuntimeError("Packrat and Bounded Recursion are not compatible")
         if not ParserElement._packratEnabled:
             ParserElement._packratEnabled = True
             if cache_size_limit is None:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4476,7 +4476,7 @@ class Forward(ParseElementEnhance):
                         new_loc, new_result = prev_loc, prev_result
                     # the match did not get better: we are done
                     if new_loc <= prev_loc:
-                        return prev_loc, prev_result
+                        return prev_loc, prev_result.copy()
                     # the match did get better: see if we can improve further
                     else:
                         prev_loc, prev_result = memo[key] = new_loc, new_result

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4492,8 +4492,6 @@ class Forward(ParseElementEnhance):
                                 raise
                         prev_loc, prev_peek = memo[self, False] = new_loc, new_peek
 
-
-
     def leaveWhitespace(self, recursive=True):
         self.skipWhitespace = False
         return self

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -778,7 +778,7 @@ class ParserElement(ABC):
     @staticmethod
     def disable_memoization():
         """
-        Disables active Packrat or Left Recursion parsing and their memooization
+        Disables active Packrat or Left Recursion parsing and their memoization
 
         This method also works if neither Packrat nor Left Recursion are enabled.
         This makes it safe to call before activating Packrat nor Left Recursion
@@ -809,7 +809,7 @@ class ParserElement(ABC):
             print(E.parseString("1+2+3"))
 
         Searching the ideal recursion depth requires matching elements at least one
-        additional time. In addition, recusion search naturally memoizes matches and
+        additional time. In addition, recursion search naturally memoizes matches and
         may thus skip evaluation during backtracking. This may break existing programs
         with parse actions which rely on side-effects.
 

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4443,7 +4443,7 @@ class Forward(ParseElementEnhance):
                 prev_loc, prev_result = memo[self]
                 if isinstance(prev_result, Exception):
                     raise prev_result
-                return prev_loc, prev_result
+                return prev_loc, prev_result.copy()
             except KeyError:
                 # we are searching for the best result – keep on improving
                 prev_loc, prev_result = memo[self] = loc, ParseException(

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -807,14 +807,20 @@ class ParserElement(ABC):
 
             E = pp.Forward("E")
             num = pp.Word(pp.nums)
+            # match `num`, or `num '+' num`, or `num '+' num '+' num`, ...
             E <<= E + '+' - num | num
 
             print(E.parseString("1+2+3"))
 
-        Searching the ideal recursion depth requires matching elements at least one
-        additional time. In addition, recursion search naturally memoizes matches and
-        may thus skip evaluation during backtracking. This may break existing programs
-        with parse actions which rely on side-effects.
+        Recursion search naturally memoizes matches of ``Forward`` elements and may
+        thus skip reevaluation of parse actions during backtracking. This may break
+        programs with parse actions which rely on strict ordering of side-effects.
+
+        Parameters:
+
+        - cache_size_limit - (default=``None``) - memoize at most this many
+          ``Forward`` elements during matching; if ``None`` (the default),
+          memoize all ``Forward`` elements.
 
         Bounded Recursion parsing works similar but not identical to Packrat parsing,
         thus the two cannot be used together. Use ``force=True`` to disable any

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -522,7 +522,7 @@ class ParseResults:
         Returns a new copy of a :class:`ParseResults` object.
         """
         ret = ParseResults(self._toklist)
-        ret._tokdict = dict(**self._tokdict)
+        ret._tokdict = self._tokdict.copy()
         ret._parent = self._parent
         ret._all_names |= self._all_names
         ret._name = self._name

--- a/pyparsing/testing.py
+++ b/pyparsing/testing.py
@@ -62,7 +62,7 @@ class pyparsing_test:
             else:
                 self._save_context["packrat_cache_size"] = None
             self._save_context["packrat_parse"] = ParserElement._parse
-            self._save_context["recursion_enabled"] = ParserElement._bounded_recursion_enabled
+            self._save_context["recursion_enabled"] = ParserElement._left_recursion_enabled
 
             self._save_context["__diag__"] = {
                 name: getattr(__diag__, name) for name in __diag__._all_names
@@ -99,7 +99,7 @@ class pyparsing_test:
                 ParserElement.enablePackrat(self._save_context["packrat_cache_size"])
             else:
                 ParserElement._parse = self._save_context["packrat_parse"]
-            ParserElement._bounded_recursion_enabled = self._save_context["recursion_enabled"]
+            ParserElement._left_recursion_enabled = self._save_context["recursion_enabled"]
 
             __compat__.collect_all_And_tokens = self._save_context["__compat__"]
 

--- a/pyparsing/testing.py
+++ b/pyparsing/testing.py
@@ -20,6 +20,7 @@ class pyparsing_test:
         """
         Context manager to be used when writing unit tests that modify pyparsing config values:
          - packrat parsing
+         - bounded recursion parsing
          - default whitespace characters.
          - default keyword characters
          - literal string auto-conversion class
@@ -61,6 +62,7 @@ class pyparsing_test:
             else:
                 self._save_context["packrat_cache_size"] = None
             self._save_context["packrat_parse"] = ParserElement._parse
+            self._save_context["recursion_enabled"] = ParserElement._bounded_recursion_enabled
 
             self._save_context["__diag__"] = {
                 name: getattr(__diag__, name) for name in __diag__._all_names
@@ -97,6 +99,7 @@ class pyparsing_test:
                 ParserElement.enablePackrat(self._save_context["packrat_cache_size"])
             else:
                 ParserElement._parse = self._save_context["packrat_parse"]
+            ParserElement._bounded_recursion_enabled = self._save_context["recursion_enabled"]
 
             __compat__.collect_all_And_tokens = self._save_context["__compat__"]
 

--- a/pyparsing/util.py
+++ b/pyparsing/util.py
@@ -119,6 +119,52 @@ class _FifoCache:
         self.clear = types.MethodType(clear, self)
 
 
+class LRUMemo:
+    """
+    A memoizing mapping that retains `capacity` deleted items
+
+    The memo tracks retained items by their access order; once `capacity` items
+    are retained, the least recently used item is discarded.
+    """
+    def __init__(self, capacity):
+        self._capacity = capacity
+        self._active = {}
+        self._memory = collections.OrderedDict()
+
+    def __getitem__(self, key):
+        try:
+            return self._active[key]
+        except KeyError:
+            self._memory.move_to_end(key)
+            return self._memory[key]
+
+    def __setitem__(self, key, value):
+        self._memory.pop(key, None)
+        self._active[key] = value
+
+    def __delitem__(self, key):
+        try:
+            value = self._active.pop(key)
+        except KeyError:
+            pass
+        else:
+            while len(self._memory) >= self._capacity:
+                self._memory.popitem(last=False)
+            self._memory[key] = value
+
+    def clear(self):
+        self._active.clear()
+        self._memory.clear()
+
+
+class UnboundedMemo(dict):
+    """
+    A memoizing mapping that retains all deleted items
+    """
+    def __delitem__(self, key):
+        pass
+
+
 def _escapeRegexRangeChars(s):
     # escape these chars: ^-[]
     for c in r"\^-[]":

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8220,6 +8220,6 @@ Test2_WithoutPackrat.suite_context = ppt.reset_pyparsing_context().save()
 Test2_WithoutPackrat.save_suite_context = ppt.reset_pyparsing_context().save()
 
 default_suite_context = ppt.reset_pyparsing_context().save()
-pp.ParserElement.enable_bounded_recursion()
+pp.ParserElement.enable_left_recursion()
 recursion_suite_context = ppt.reset_pyparsing_context().save()
 default_suite_context.restore()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1609,7 +1609,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             pp.QuotedString("", "\\")
 
     def testRepeater(self):
-        if ParserElement._packratEnabled:
+        if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
             print("skipping this test, not compatible with packratting")
             return
 
@@ -1715,7 +1715,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
     def testRepeater2(self):
         """test matchPreviousLiteral with empty repeater"""
 
-        if ParserElement._packratEnabled:
+        if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
             print("skipping this test, not compatible with packratting")
             return
 
@@ -1735,7 +1735,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
     def testRepeater3(self):
         """test matchPreviousLiteral with multiple repeater tokens"""
 
-        if ParserElement._packratEnabled:
+        if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
             print("skipping this test, not compatible with packratting")
             return
 
@@ -1755,7 +1755,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
     def testRepeater4(self):
         """test matchPreviousExpr with multiple repeater tokens"""
 
-        if ParserElement._packratEnabled:
+        if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
             print("skipping this test, not compatible with packratting")
             return
 
@@ -1782,7 +1782,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
     def testRepeater5(self):
         """a simplified testRepeater4 to examine matchPreviousExpr with a single repeater token"""
 
-        if ParserElement._packratEnabled:
+        if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
             print("skipping this test, not compatible with packratting")
             return
 
@@ -6712,6 +6712,8 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             self.fail("failed to raise exception when matching empty string")
 
     def testExplainException(self):
+        if ParserElement._left_recursion_enabled:
+            return
         expr = pp.Word(pp.nums).setName("int") + pp.Word(pp.alphas).setName("word")
         try:
             expr.parseString("123 355")
@@ -8074,12 +8076,8 @@ class Test9_WithLeftRecursionParsing(Test2_WithoutPackrat):
 
     def setUp(self):
         recursion_suite_context.restore()
-        # TODO: This is a workaround to skip tests not compatible with memoization.
-        #       Should do so explicitly instead of re-using the Packrat flag.
-        ParserElement._packratEnabled = True
 
     def tearDown(self):
-        ParserElement._packratEnabled = False
         default_suite_context.restore()
 
     def test000_assert_packrat_status(self):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -287,7 +287,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         test("-9", -9)
         test("--9", 9)
         test("-E", -math.e)
-        test("9 + 3 + 6", 9 + 3 + 6)
+        test("9 + 3 + 5", 9 + 3 + 5)
         test("9 + 3 / 11", 9 + 3.0 / 11)
         test("(9 + 3)", (9 + 3))
         test("(9+3) / 11", (9 + 3.0) / 11)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8076,11 +8076,11 @@ class Test8_WithUnboundedPackrat(Test2_WithoutPackrat):
 
 class Test9_WithLeftRecursionParsing(Test2_WithoutPackrat):
     """
-    rerun Test2 tests, now with unbounded packrat cache
+    rerun Test2 tests, now with unbounded left recursion cache
     """
 
     def setUp(self):
-        recursion_suite_context.restore()
+        ParserElement.enable_left_recursion(force=True)
 
     def tearDown(self):
         default_suite_context.restore()
@@ -8088,6 +8088,28 @@ class Test9_WithLeftRecursionParsing(Test2_WithoutPackrat):
     def test000_assert_packrat_status(self):
         print("Left-Recursion enabled:", ParserElement._left_recursion_enabled)
         self.assertTrue(ParserElement._left_recursion_enabled, "left recursion not enabled")
+        self.assertIsInstance(ParserElement.recursion_memos, pp.util.UnboundedMemo)
+
+
+class Test10_WithLeftRecursionParsingBoundedMemo(Test2_WithoutPackrat):
+    """
+    rerun Test2 tests, now with bounded left recursion cache
+    """
+
+    def setUp(self):
+        ParserElement.enable_left_recursion(cache_size_limit=4, force=True)
+
+    def tearDown(self):
+        default_suite_context.restore()
+
+    def test000_assert_packrat_status(self):
+        print("Left-Recursion enabled:", ParserElement._left_recursion_enabled)
+        self.assertTrue(ParserElement._left_recursion_enabled, "left recursion not enabled")
+        self.assertIsInstance(ParserElement.recursion_memos, pp.util.LRUMemo)
+        # check that the cache matches roughly what we expect
+        # – it may be larger due to action handling
+        self.assertLessEqual(ParserElement.recursion_memos._capacity, 4)
+        self.assertGreater(ParserElement.recursion_memos._capacity * 3, 4)
 
 
 class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8067,6 +8067,26 @@ class Test8_WithUnboundedPackrat(Test2_WithoutPackrat):
         )
 
 
+class Test9_WithLeftRecursionParsing(Test2_WithoutPackrat):
+    """
+    rerun Test2 tests, now with unbounded packrat cache
+    """
+
+    def setUp(self):
+        recursion_suite_context.restore()
+        # TODO: This is a workaround to skip tests not compatible with memoization.
+        #       Should do so explicitly instead of re-using the Packrat flag.
+        ParserElement._packratEnabled = True
+
+    def tearDown(self):
+        ParserElement._packratEnabled = False
+        default_suite_context.restore()
+
+    def test000_assert_packrat_status(self):
+        print("Left-Recursion enabled:", ParserElement._left_recursion_enabled)
+        self.assertTrue(ParserElement._left_recursion_enabled, "left recursion not enabled")
+
+
 class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
     """
     Tests for recursive parsing

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8166,7 +8166,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
         self.assertEqual(expr.parseString("1----3")[0], 1----3)
         self.assertEqual(expr.parseString("1+2*3")[0], 1+2*3)
         self.assertEqual(expr.parseString("1*2+3")[0], 1*2+3)
-        self.assertEqual(expr.parseString("1*2^3")[0], 1*2^3)
+        self.assertEqual(expr.parseString("1*2^3")[0], 1*2**3)
         self.assertEqual(expr.parseString("4^3^2^1")[0], 4**3**2**1)
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1610,7 +1610,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
     def testRepeater(self):
         if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
-            print("skipping this test, not compatible with packratting")
+            print("skipping this test, not compatible with memoization")
             return
 
         first = pp.Word("abcdef").setName("word1")
@@ -1716,7 +1716,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         """test matchPreviousLiteral with empty repeater"""
 
         if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
-            print("skipping this test, not compatible with packratting")
+            print("skipping this test, not compatible with memoization")
             return
 
         first = pp.Optional(pp.Word("abcdef").setName("words1"))
@@ -1736,7 +1736,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         """test matchPreviousLiteral with multiple repeater tokens"""
 
         if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
-            print("skipping this test, not compatible with packratting")
+            print("skipping this test, not compatible with memoization")
             return
 
         first = pp.Word("a") + pp.Word("d")
@@ -1756,7 +1756,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         """test matchPreviousExpr with multiple repeater tokens"""
 
         if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
-            print("skipping this test, not compatible with packratting")
+            print("skipping this test, not compatible with memoization")
             return
 
         first = pp.Group(pp.Word(pp.alphas) + pp.Word(pp.alphas))
@@ -1783,7 +1783,7 @@ class Test2_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         """a simplified testRepeater4 to examine matchPreviousExpr with a single repeater token"""
 
         if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
-            print("skipping this test, not compatible with packratting")
+            print("skipping this test, not compatible with memoization")
             return
 
         first = pp.Word(pp.alphas)
@@ -8100,7 +8100,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_repeat_as_recurse(self):
         """repetition rules formulated with recursion"""
-        one_or_more = pp.Forward("one_or_more")
+        one_or_more = pp.Forward()("one_or_more")
         one_or_more <<= one_or_more + "a" | "a"
         self.assertParseResultsEquals(
             one_or_more.parseString("a"),
@@ -8110,7 +8110,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
             one_or_more.parseString("aaa aa"),
             expected_list=["a", "a", "a", "a", "a"],
         )
-        delimited_list = pp.Forward("delimited_list")
+        delimited_list = pp.Forward()("delimited_list")
         delimited_list <<= delimited_list + pp.Suppress(',') + "b" | "b"
         self.assertParseResultsEquals(
             delimited_list.parseString("b"),
@@ -8127,7 +8127,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_binary_recursive(self):
         """parsing of single left-recursive binary operator"""
-        expr = pp.Forward("expr")
+        expr = pp.Forward()("expr")
         num = pp.Word(pp.nums)
         expr <<= expr + '+' - num | num
         self.assertParseResultsEquals(
@@ -8141,7 +8141,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_binary_associative(self):
         """associative is preserved for single left-recursive binary operator"""
-        expr = pp.Forward("expr")
+        expr = pp.Forward()("expr")
         num = pp.Word(pp.nums)
         expr <<= pp.Group(expr) + '+' - num | num
         self.assertParseResultsEquals(
@@ -8155,7 +8155,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_add_sub(self):
         """indirectly left-recursive/associative add/sub calculator"""
-        expr = pp.Forward("expr")
+        expr = pp.Forward()("expr")
         num = pp.Word(pp.nums).setParseAction(lambda t: int(t[0]))
         expr <<= (
             (expr + '+' - num).setParseAction(lambda t: t[0] + t[2])
@@ -8171,11 +8171,11 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
     def test_math(self):
         """precedence climbing parser for math"""
         # named references
-        expr = pp.Forward("expr")
-        add_sub = pp.Forward("add_sub")
-        mul_div = pp.Forward("mul_div")
-        power = pp.Forward("power")
-        terminal = pp.Forward("terminal")
+        expr = pp.Forward()("expr")
+        add_sub = pp.Forward()("add_sub")
+        mul_div = pp.Forward()("mul_div")
+        power = pp.Forward()("power")
+        terminal = pp.Forward()("terminal")
         # concrete rules
         number = pp.Word(pp.nums).setParseAction(lambda t: int(t[0]))
         signed = ('+' - expr) | ('-' - expr).setParseAction(lambda t: -t[1])
@@ -8216,13 +8216,13 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_terminate_empty(self):
         """Recursion with ``Empty`` terminates"""
-        empty = pp.Forward('e')
+        empty = pp.Forward()('e')
         empty <<= empty + pp.Empty() | pp.Empty()
         self.assertParseResultsEquals(empty.parseString(""), expected_list=[])
 
     def test_non_peg(self):
         """Recursion works for non-PEG operators"""
-        expr = pp.Forward('expr')
+        expr = pp.Forward()('expr')
         expr <<= expr + "a" ^ expr + "ab" ^ expr + "abc" ^ "."
         self.assertParseResultsEquals(
             expr.parseString(".abcabaabc"),

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8080,6 +8080,33 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
     def tearDown(self):
         default_suite_context.restore()
 
+    def test_repeat_as_recurse(self):
+        """repetition rules formulated with recursion"""
+        one_or_more = pp.Forward("one_or_more")
+        one_or_more <<= one_or_more + "a" | "a"
+        self.assertParseResultsEquals(
+            one_or_more.parseString("a"),
+            expected_list=["a"],
+        )
+        self.assertParseResultsEquals(
+            one_or_more.parseString("aaa aa"),
+            expected_list=["a", "a", "a", "a", "a"],
+        )
+        delimited_list = pp.Forward("delimited_list")
+        delimited_list <<= delimited_list + pp.Suppress(',') + "b" | "b"
+        self.assertParseResultsEquals(
+            delimited_list.parseString("b"),
+            expected_list=["b"],
+        )
+        self.assertParseResultsEquals(
+            delimited_list.parseString("b,b"),
+            expected_list=["b", "b"],
+        )
+        self.assertParseResultsEquals(
+            delimited_list.parseString("b,b , b, b,b"),
+            expected_list=["b", "b", "b", "b", "b"],
+        )
+
     def test_binary_recursive(self):
         """parsing of single left-recursive binary operator"""
         expr = pp.Forward("expr")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8178,9 +8178,9 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
     def test_non_peg(self):
         """Recursion works for non-PEG operators"""
         expr = pp.Forward('expr')
-        expr <<= expr + "a" ^ e + "ab" ^ e + "abc"
+        expr <<= expr + "a" ^ expr + "ab" ^ expr + "abc"
         self.assertParseResultsEquals(
-            e.parseString("abcabaabc"),
+            expr.parseString("abcabaabc"),
             expected_list=["abc", "ab", "a", "abc"]
         )
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8169,6 +8169,21 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
         self.assertEqual(expr.parseString("1*2^3")[0], 1*2**3)
         self.assertEqual(expr.parseString("4^3^2^1")[0], 4**3**2**1)
 
+    def test_terminate_empty(self):
+        """Recursion with ``Empty`` terminates"""
+        empty = pp.Forward('e')
+        empty <<= empty + pp.Empty() | pp.Empty()
+        self.assertParseResultsEquals(empty.parseString(""), expected_list=[])
+
+    def test_non_peg(self):
+        """Recursion works for non-PEG operators"""
+        expr = pp.Forward('expr')
+        expr <<= expr + "a" ^ e + "ab" ^ e + "abc"
+        self.assertParseResultsEquals(
+            e.parseString("abcabaabc"),
+            expected_list=["abc", "ab", "a", "abc"]
+        )
+
 
 # force clear of packrat parsing flags before saving contexts
 pp.ParserElement._packratEnabled = False

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8178,10 +8178,10 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
     def test_non_peg(self):
         """Recursion works for non-PEG operators"""
         expr = pp.Forward('expr')
-        expr <<= expr + "a" ^ expr + "ab" ^ expr + "abc"
+        expr <<= expr + "a" ^ expr + "ab" ^ expr + "abc" ^ "."
         self.assertParseResultsEquals(
-            expr.parseString("abcabaabc"),
-            expected_list=["abc", "ab", "a", "abc"]
+            expr.parseString(".abcabaabc"),
+            expected_list=[".", "abc", "ab", "a", "abc"]
         )
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8067,9 +8067,39 @@ class Test8_WithUnboundedPackrat(Test2_WithoutPackrat):
         )
 
 
+class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
+    """
+    Tests for recursive parsing
+    """
+    suite_context = None
+    save_suite_context = None
+
+    def setUp(self):
+        recursion_suite_context.restore()
+
+    def test_binary_recursive(self):
+        """Parsing single left-recursive binary operator"""
+        expr = pp.Forward("expr")
+        num = pp.Word(pp.nums)
+        expr <<= expr + '+' - num | num
+        self.assertParseResultsEquals(
+            expr.parseString("1+2"),
+            expected_list=['1', '+', '2']
+        )
+        self.assertParseResultsEquals(
+            expr.parseString("1+2+3+4"),
+            expected_list=['1', '+', '2', '+', '3', '+', '4']
+        )
+
+
 # force clear of packrat parsing flags before saving contexts
 pp.ParserElement._packratEnabled = False
 pp.ParserElement._parse = pp.ParserElement._parseNoCache
 
 Test2_WithoutPackrat.suite_context = ppt.reset_pyparsing_context().save()
 Test2_WithoutPackrat.save_suite_context = ppt.reset_pyparsing_context().save()
+
+default_suite_context = ppt.reset_pyparsing_context().save()
+pp.ParserElement.enable_bounded_recursion()
+recursion_suite_context = ppt.reset_pyparsing_context().save()
+default_suite_context.restore()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8100,7 +8100,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_repeat_as_recurse(self):
         """repetition rules formulated with recursion"""
-        one_or_more = pp.Forward()("one_or_more")
+        one_or_more = pp.Forward().setName("one_or_more")
         one_or_more <<= one_or_more + "a" | "a"
         self.assertParseResultsEquals(
             one_or_more.parseString("a"),
@@ -8110,7 +8110,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
             one_or_more.parseString("aaa aa"),
             expected_list=["a", "a", "a", "a", "a"],
         )
-        delimited_list = pp.Forward()("delimited_list")
+        delimited_list = pp.Forward().setName("delimited_list")
         delimited_list <<= delimited_list + pp.Suppress(',') + "b" | "b"
         self.assertParseResultsEquals(
             delimited_list.parseString("b"),
@@ -8127,7 +8127,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_binary_recursive(self):
         """parsing of single left-recursive binary operator"""
-        expr = pp.Forward()("expr")
+        expr = pp.Forward().setName("expr")
         num = pp.Word(pp.nums)
         expr <<= expr + '+' - num | num
         self.assertParseResultsEquals(
@@ -8141,7 +8141,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_binary_associative(self):
         """associative is preserved for single left-recursive binary operator"""
-        expr = pp.Forward()("expr")
+        expr = pp.Forward().setName("expr")
         num = pp.Word(pp.nums)
         expr <<= pp.Group(expr) + '+' - num | num
         self.assertParseResultsEquals(
@@ -8155,7 +8155,7 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_add_sub(self):
         """indirectly left-recursive/associative add/sub calculator"""
-        expr = pp.Forward()("expr")
+        expr = pp.Forward().setName("expr")
         num = pp.Word(pp.nums).setParseAction(lambda t: int(t[0]))
         expr <<= (
             (expr + '+' - num).setParseAction(lambda t: t[0] + t[2])
@@ -8171,11 +8171,11 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
     def test_math(self):
         """precedence climbing parser for math"""
         # named references
-        expr = pp.Forward()("expr")
-        add_sub = pp.Forward()("add_sub")
-        mul_div = pp.Forward()("mul_div")
-        power = pp.Forward()("power")
-        terminal = pp.Forward()("terminal")
+        expr = pp.Forward().setName("expr")
+        add_sub = pp.Forward().setName("add_sub")
+        mul_div = pp.Forward().setName("mul_div")
+        power = pp.Forward().setName("power")
+        terminal = pp.Forward().setName("terminal")
         # concrete rules
         number = pp.Word(pp.nums).setParseAction(lambda t: int(t[0]))
         signed = ('+' - expr) | ('-' - expr).setParseAction(lambda t: -t[1])
@@ -8216,13 +8216,13 @@ class TestLR1_Recursion(ppt.TestParseResultsAsserts, TestCase):
 
     def test_terminate_empty(self):
         """Recursion with ``Empty`` terminates"""
-        empty = pp.Forward()('e')
+        empty = pp.Forward().setName('e')
         empty <<= empty + pp.Empty() | pp.Empty()
         self.assertParseResultsEquals(empty.parseString(""), expected_list=[])
 
     def test_non_peg(self):
         """Recursion works for non-PEG operators"""
-        expr = pp.Forward()('expr')
+        expr = pp.Forward().setName('expr')
         expr <<= expr + "a" ^ expr + "ab" ^ expr + "abc" ^ "."
         self.assertParseResultsEquals(
             expr.parseString(".abcabaabc"),


### PR DESCRIPTION
This PR adds support for direct and indirect left-recursion, according to the "bounded left-recursion" scheme. This is similar to but neither identical nor directly compatible with Packrat.

* [x] basic LR implementation
* [x] LR must be enabled like Packrat
* [x] tests for direct left recursion
* [x] tests for indirect left recursion
* [x] tests for non-PEG clause interactions
* [x] docs
* [x] ? non-action left recursion lookahead ?

Closes #287.