### PR TITLE
Test Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,17 @@ dist: xenial
 
 matrix:
   include:
-    - python: 3.6
+    - python: "3.6"
       env: TOXENV=py36
-    - python: 3.7
+    - python: "3.7"
       env: TOXENV=py37
-    - python: 3.8
+    - python: "3.8"
       env: TOXENV=py38
-    - python: 3.9
+    - python: "3.9"
       env: TOXENV=py39
-    - python: pypy3
+    - python: "3.10-dev"
+      env: TOXENV=py310
+    - python: "pypy3"
       env: TOXENV=pypy3
   fast_finish: true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,py3}
+    py{36,37,38,39,310,py3}
 
 [testenv]
 deps=coverage


### PR DESCRIPTION
Python 3.10 final was released last Monday:

https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Travis CI hasn't yet added support for `"3.10"` final:

https://travis-ci.community/t/add-python-3-10/12220

But there's still value in testing the `"3.10-dev"` nightly version, so we know the new 3.10 additions and (especially) removals don't cause problems.

