### PR TITLE
Wrap tokenlist in list if `self.resultsName` is present

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -5410,7 +5410,7 @@ class Dict(TokenConverter):
                     tokenlist[ikey] = _ParseResultsWithOffset(dictvalue[0], i)
 
         if self._asPythonDict:
-            return tokenlist.asDict()
+            return tokenlist.as_dict()
         else:
             return [tokenlist] if self.resultsName else tokenlist
 


### PR DESCRIPTION
There seems to have been a small behavior change to `class Dict()` when `asdict` was added. This restores the branch that was lost (`self.resultsName` is present).

https://github.com/pyparsing/pyparsing/commit/3c495dbb0fb80cd1600984919a45a5c54baa2806#diff-651b49e05968bd7f42614f05b7e9d94b30f52db27eb692ce20ef87e9799c624f