### PR TITLE
Add equality comparison to ParseResults

### DIFF
--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -250,6 +250,12 @@ class ParseResults:
     def __reversed__(self) -> Iterator:
         return iter(self._toklist[::-1])
 
+    def __eq__(self, o: object) -> bool:
+        if isinstance(o, self.__class__):
+            return all(map(lambda slot: getattr(self, slot) == getattr(o, slot), ParseResults.__slots__))
+        else:
+            return False
+
     def keys(self):
         return iter(self._tokdict)
 

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -679,6 +679,15 @@ class TestWhitespaceMethods(PyparsingExpressionTestCase):
         # ),
     ]
 
+class TestResult(unittest.TestCase):
+    def test_result_equality(self):
+        text ="abc"
+        r1 = pp.Literal("abc").parse_string(text)
+        r2 = pp.Word(pp.alphas).parse_string(text)
+        r3 = pp.Word(pp.alphas).parse_string("ab")
+        self.assertEqual(r1, r2)
+        self.assertNotEqual(r1, r3)
+
 
 def _get_decl_line_no(cls):
     import inspect


### PR DESCRIPTION
Hi there,
I really enjoy using this library! Thanks for your great work

While implementing a remembering ParserElement I missed the ability to check two ParseResults for Equality. So I added it.