### PR TITLE
Added min/max keyword arguments for delimited_list

### DIFF
--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -14,6 +14,8 @@ def delimited_list(
     expr: Union[str, ParserElement],
     delim: Union[str, ParserElement] = ",",
     combine: bool = False,
+    _min: OptionalType[int] = None,
+    _max: OptionalType[int] = None,
     *,
     allow_trailing_delim: bool = False,
 ) -> ParserElement:
@@ -46,7 +48,12 @@ def delimited_list(
     if not combine:
         delim = Suppress(delim)
 
-    delimited_list_expr = expr + ZeroOrMore(delim + expr)
+    if _min is None and _max is None:
+        delimited_list_expr = expr + ZeroOrMore(delim + expr)
+    else:
+        _min = ... if _min is None else max(0, _min - 1)
+        _max = ... if _max is None else max(0, _max - 1)
+        delimited_list_expr = expr + (delim + expr)[_min, _max]
 
     if allow_trailing_delim:
         delimited_list_expr += Opt(delim)

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -14,8 +14,8 @@ def delimited_list(
     expr: Union[str, ParserElement],
     delim: Union[str, ParserElement] = ",",
     combine: bool = False,
-    _min: OptionalType[int] = None,
-    _max: OptionalType[int] = None,
+    min: OptionalType[int] = None,
+    max: OptionalType[int] = None,
     *,
     allow_trailing_delim: bool = False,
 ) -> ParserElement:
@@ -48,12 +48,15 @@ def delimited_list(
     if not combine:
         delim = Suppress(delim)
 
-    if _min is None and _max is None:
-        delimited_list_expr = expr + ZeroOrMore(delim + expr)
-    else:
-        _min = ... if _min is None else max(0, _min - 1)
-        _max = ... if _max is None else max(0, _max - 1)
-        delimited_list_expr = expr + (delim + expr)[_min, _max]
+    if min is not None:
+        if min < 1:
+            raise ValueError("min must be greater than 0")
+        min -= 1
+    if max is not None:
+        if min is not None and max <= min:
+            raise ValueError("max must be greater than, or equal to min")
+        max -= 1
+    delimited_list_expr = expr + (delim + expr)[min, max]
 
     if allow_trailing_delim:
         delimited_list_expr += Opt(delim)

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -270,6 +270,18 @@ class TestRepetition(PyparsingExpressionTestCase):
             expected_list=["xxyx", "xy", "y", "xxyx", "yxx", "xy"],
         ),
         PpTestSpec(
+            desc="Using delimited_list (comma is the default delimiter) with minimum size",
+            expr=pp.delimited_list(pp.Word(pp.alphas), _min=3),
+            text="xxyx,xy",
+            expected_fail_locn=7,
+        ),
+        PpTestSpec(
+            desc="Using delimited_list (comma is the default delimiter) with maximum size",
+            expr=pp.delimited_list(pp.Word(pp.alphas), _max=3),
+            text="xxyx,xy,y,xxyx,yxx, xy,",
+            expected_list=["xxyx", "xy", "y"],
+        ),
+        PpTestSpec(
             desc="Using delimited_list, with ':' delimiter",
             expr=pp.delimited_list(
                 pp.Word(pp.hexnums, exact=2), delim=":", combine=True

--- a/tests/test_simple_unit.py
+++ b/tests/test_simple_unit.py
@@ -271,13 +271,13 @@ class TestRepetition(PyparsingExpressionTestCase):
         ),
         PpTestSpec(
             desc="Using delimited_list (comma is the default delimiter) with minimum size",
-            expr=pp.delimited_list(pp.Word(pp.alphas), _min=3),
+            expr=pp.delimited_list(pp.Word(pp.alphas), min=3),
             text="xxyx,xy",
             expected_fail_locn=7,
         ),
         PpTestSpec(
             desc="Using delimited_list (comma is the default delimiter) with maximum size",
-            expr=pp.delimited_list(pp.Word(pp.alphas), _max=3),
+            expr=pp.delimited_list(pp.Word(pp.alphas), max=3),
             text="xxyx,xy,y,xxyx,yxx, xy,",
             expected_list=["xxyx", "xy", "y"],
         ),

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7714,6 +7714,25 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             expr, source, [s.strip() for s in source.split(",")]
         )
 
+    def testDelimitedListMinMax(self):
+        source = "ABC, ABC,ABC"
+        with self.assertRaises(ValueError, msg="min must be greater than 0"):
+            pp.delimited_list("ABC", min=0)
+        with self.assertRaises(ValueError, msg="max must be greater than, or equal to min"):
+            pp.delimited_list("ABC", min=1, max=0)
+        with self.assertRaises(pp.ParseException):
+            pp.delimited_list("ABC", min=4).parse_string(source)
+
+        source_expr_pairs = [
+            ("ABC,  ABC", pp.delimited_list("ABC", max=2)),
+            (source, pp.delimited_list("ABC", min=2, max=4)),
+        ]
+        for source, expr in source_expr_pairs:
+            print(str(expr))
+            self.assertParseAndCheckList(
+                expr, source, [s.strip() for s in source.split(",")]
+            )
+
     def testEnableDebugOnNamedExpressions(self):
         """
         - enable_debug_on_named_expressions - flag to auto-enable debug on all subsequent


### PR DESCRIPTION
As discussed in #330, here's a patch to add `max` to `delimited_list`.

A few notes/questions:
- Added `min` in addition to `max`, let me know if you'd rather only have `max`
- Used the names `_min` and `_max` to avoid collision with Python built-ins
- Currently, `delimitedList('A', _max=0)` has the same effect as `delimitedList('A', _max=1)`. Same for `_min=0`/`_min=1`.
  Should `_min=0`/`_max=0` raise a `ValueError` instead?