### PR TITLE
Mark `pyparsing` as a typed package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ setup(  # Distribution meta-data
     extras_require={
         "diagrams": ["railroad-diagrams", "jinja2"],
     },
-    package_data={"pyparsing.diagram": ["*.jinja2"]},
+    package_data={
+        "pyparsing.diagram": ["*.jinja2"],
+        "pyparsing": ["py.typed"],
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -53,5 +56,6 @@ setup(  # Distribution meta-data
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
+        "Typing :: Typed",
     ],
 )


### PR DESCRIPTION
Packages have to distribute a `py.typed` file in order to signal type checkers that the package is typed (see [PEP 561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information)).
This file was previously missing though, meaning that downstream users were unable to benefit from pyparsings' type annotations.