### PR TITLE
Typo in an example code

### DIFF
--- a/docs/whats_new_in_3_0_0.rst
+++ b/docs/whats_new_in_3_0_0.rst
@@ -133,7 +133,7 @@ Instead of writing::
 
 you will be able to write::
 
-    identifier = pp.Word(pp.indentchars, pp.identbodychars)
+    identifier = pp.Word(pp.identchars, pp.identbodychars)
 
 Those constants have also been added to all the Unicode string classes::
 


### PR DESCRIPTION
Just a typo in an example code in the [What's New in Pyparsing 3.0.0 - New string constants `identchars` and `identbodychars` to help in defining identifier Word expressions](https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#new-string-constants-identchars-and-identbodychars-to-help-in-defining-identifier-word-expressions), which made the code unrunnable.

Because this is a tiny document change, I don't mind if you merge it or squash it with other commits or do whatever you like.