### PR TITLE
Fix type annotations of Forward dunder-methods

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -5178,7 +5178,7 @@ class Forward(ParseElementEnhance):
         super().__init__(other, savelist=False)
         self.lshift_line = None
 
-    def __lshift__(self, other):
+    def __lshift__(self, other) -> "Forward":
         if hasattr(self, "caller_frame"):
             del self.caller_frame
         if isinstance(other, str_type):
@@ -5195,10 +5195,10 @@ class Forward(ParseElementEnhance):
         self.lshift_line = traceback.extract_stack(limit=2)[-2]
         return self
 
-    def __ilshift__(self, other):
+    def __ilshift__(self, other) -> "Forward":
         return self << other
 
-    def __or__(self, other):
+    def __or__(self, other) -> "ParserElement":
         caller_line = traceback.extract_stack(limit=2)[-2]
         if (
             __diag__.warn_on_match_first_with_lshift_operator

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,3 +8,12 @@ After forking the pyparsing repo, and cloning your fork locally, install the lib
 Run the tests to ensure your environment is setup 
      
      python -m unittest discover tests
+
+### mypy ignore tests
+
+`tests/mypy-ignore-cases/` is populated with python files which are meant to be
+checked using `mypy --warn-unused-ignores`.
+
+To check these files, run
+
+    tox -e mypy-tests

--- a/tests/mypy-ignore-cases/forward_methods.py
+++ b/tests/mypy-ignore-cases/forward_methods.py
@@ -1,0 +1,14 @@
+import pyparsing as pp
+
+# first, some basic validation: forward is a ParserElement, so is Literal
+# MatchFirst([Forward(), Literal(...)]) should also be okay
+e: pp.ParserElement = pp.Forward()
+e = pp.Literal()
+e = pp.MatchFirst([pp.Forward(), pp.Literal("hi there")])
+# confirm that it isn't returning Any because it cannot be assigned to a str
+x: str = pp.Forward() | pp.Literal("oops")  # type: ignore[assignment]
+
+# confirm that `Forward.__or__` has the right behavior
+e = pp.Forward() | pp.Literal("nice to meet you")
+# and that it isn't returning Any because it cannot be assigned to an int
+y: int = pp.Forward() | pp.Literal("oops")  # type: ignore[assignment]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters=true
 envlist =
-    py{36,37,38,39,310,py3},pyparsing_packaging
+    py{36,37,38,39,310,py3},mypy-test,pyparsing_packaging
 isolated_build = True
 
 [testenv]
@@ -9,6 +9,12 @@ deps=coverage
 extras=diagrams
 commands=
     coverage run --parallel --branch -m unittest
+
+[testenv:mypy-test]
+deps = mypy==0.960
+# note: cd to tests/ to avoid mypy trying to check pyparsing (which fails)
+changedir = tests
+commands = mypy --show-error-codes --warn-unused-ignores mypy-ignore-cases/
 
 [testenv:pyparsing_packaging]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,14 @@ extras=diagrams
 commands=
     coverage run --parallel --branch -m unittest
 
-[testenv:mypy-test]
-deps = mypy==0.960
-# note: cd to tests/ to avoid mypy trying to check pyparsing (which fails)
-changedir = tests
-commands = mypy --show-error-codes --warn-unused-ignores mypy-ignore-cases/
+# commented out mypy-test until CI can support running it
+# see: https://github.com/pyparsing/pyparsing/pull/402
+#
+# [testenv:mypy-test]
+# deps = mypy==0.960
+# # note: cd to tests/ to avoid mypy trying to check pyparsing (which fails)
+# changedir = tests
+# commands = mypy --show-error-codes --warn-unused-ignores mypy-ignore-cases/
 
 [testenv:pyparsing_packaging]
 deps=


### PR DESCRIPTION
The `__lshift__`, `__ilshift__`, and `__or__` methods each return a ParserElement object, but have no annotated return type. The result is that the following code will not type check:

    def foo() -> pp.ParserElement:
        expr = pp.Forward()
        expr <<= bar()
        return expr | pp.Literal("baz")

whereas the code will type check if the return line is changed to

    return pp.MatchFirst([expr, pp.Literal("baz")])

This is a bug in the types which can be resolved fairly simply with some return type annotations.

Testing is more complicated. Testing annotation accuracy is a relatively novel space with a few options, none of which can be considered standard as of yet.

Many solutions require learning a new toolchain only for that purpose. However, one of the lower-impact options is to use `mypy --warn-unused-ignores` to check that annotations satisfy some constraints. This isn't the most precise test possible, but it's simple and uses a widely known and familiar tool for the job.
`tox -e mypy-tests` is a new tox env which calls `mypy` in the desired way. We can confirm with a new test case file that `tox -e mypy-tests` fails prior to this change to `pyparsing/` and that it passes with the change made.

---

Some follow-up notes.
- The testing strategy is documented [in this section of the typing readthedocs](https://typing.readthedocs.io/en/latest/source/quality.html), but I contributed that guide to the docs, so there's authorship bias.
- `mypy` doesn't run cleanly from the repo root. I believe it's importing the local `pyparsing` package tree and failing on it. If this is a concern, moving to a `src/` tree setup or making `mypy` pass on `pyparsing/` would work, but I don't think anything simpler would suffice. (`--exclude` does not work.)
- I put the mypy test files in `tests/` but could use a different dir if there's any concern about file naming and `unittest` discovery. Under pytest, I've used norecursedirs -- I don't think unittest has a similar option.
- The pin in `tox` to `mypy==0.960` is intentional, as I've seen issues in other projects when mypy does a release and builds start failing due to a new check. This could be done in a requirements.txt if that's desired, of course.
- I think it would be a good idea to work up a `mypy.ini` config which makes `mypy pyparsing/` pass. Any typing changes can be gradual -- I've seen this mentioned in another thread here -- but publishing types without validation passing, even with some permissive options, leaves the door open to weird things. I'd be happy to help with this and the minimal additional annotations it would probably require.