### PR TITLE
Update CI to avoid `tox -e ALL`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,24 +17,15 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       matrix:
+        os: ["ubuntu-latest"]
+        toxenv: [py, pyparsing_packaging]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
-          - python-version: "3.6"
-            toxenv: py36
-          - python-version: "3.7"
-            toxenv: py37
-          - python-version: "3.8"
-            toxenv: py38
-          - python-version: "3.9"
-            toxenv: py39
           - python-version: "3.10"
-            toxenv: py310
-          - python-version: "3.10"
-            toxenv: py310
             os: macos-latest
           - python-version: "pypy-3.7"
-            toxenv: pypy3
     env:
-      TOXENV: ${{ matrix.toxenv }}
+      TOXENV: ${{ matrix.toxenv || 'py' }}
     steps:
       - uses: actions/checkout@v2
 
@@ -49,10 +40,10 @@ jobs:
           python -m pip install tox codecov railroad-diagrams Jinja2
 
       - name: Test
-        run: tox -e ALL
+        run: tox
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' && matrix.toxenv == 'py' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: codecov


### PR DESCRIPTION
Motivated by #402, these are the changes which I think are needed on the workflow. I've preserved the current testing to the best of my knowledge, but I'm happy to reduce the matrix if desired. (e.g. I'm not sure that `pyparsing_packaging` needs to run on every version.)

If this change is accepted, I can rebase #402 onto this in order to use the matrix config to add a py3.10 `mypy-test` build.

---

When this is used, it means that no new toxenv can be introduced which is incompatible with pypy. This poses an issue for work using mypy to check annotations, as pypy currently cannot install it.

In order to move away from `-e ALL`, expand the github actions matrix config to generate the list of desirable runs. The TOXENV=py setting is used to run the main testenv on the current interpreter, and the TOXENV=pyparsing_packaging builds (which run today) are preserved except for on macos and pypy.

The codecov step now looks for `TOXENV=py` in addition to other matrix attributes.