### PR TITLE
Enable mypy-test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
   pull_request:
     paths:
-      - .github/workflows/cis.yml
+      - .github/workflows/ci.yml
       - pyparsing/*
       - pyproject.toml
       - tox.ini
@@ -23,6 +23,8 @@ jobs:
         include:
           - python-version: "3.10"
             os: macos-latest
+          - python-version: "3.10"
+            toxenv: mypy-test
           - python-version: "pypy-3.7"
     env:
       TOXENV: ${{ matrix.toxenv || 'py' }}

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,11 @@ extras=diagrams
 commands=
     coverage run --parallel --branch -m unittest
 
-# commented out mypy-test until CI can support running it
-# see: https://github.com/pyparsing/pyparsing/pull/402
-#
-# [testenv:mypy-test]
-# deps = mypy==0.960
-# # note: cd to tests/ to avoid mypy trying to check pyparsing (which fails)
-# changedir = tests
-# commands = mypy --show-error-codes --warn-unused-ignores mypy-ignore-cases/
+[testenv:mypy-test]
+deps = mypy==0.960
+# note: cd to tests/ to avoid mypy trying to check pyparsing (which fails)
+changedir = tests
+commands = mypy --show-error-codes --warn-unused-ignores mypy-ignore-cases/
 
 [testenv:pyparsing_packaging]
 deps=


### PR DESCRIPTION
With the updated matrix build config, it's now possible to add a py3.10 build to run `tox -e mypy-test`.

Also, fix a bug in the workflow in on.pull_request.paths