### PR TITLE
fix Sphinx errors/warnings

### DIFF
--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -1283,13 +1283,15 @@ Common string and token constants
 
     ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ
 
+.. _identchars:
+
 - ``identchars`` - a string containing characters that are valid as initial identifier characters::
 
     ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyzª
     µºÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ
 
 - ``identbodychars`` - a string containing characters that are valid as identifier body characters (those following a
-valid leading identifier character as given in identchars_)::
+  valid leading identifier character as given in identchars_)::
 
     0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyzª
     µ·ºÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1081,7 +1081,7 @@ class ParserElement(ABC):
           an object with attributes if the given parser includes results names.
 
         If the input string is required to match the entire grammar, ``parse_all`` flag must be set to ``True``. This
-        is also equivalent to ending the grammar with :class:`StringEnd`().
+        is also equivalent to ending the grammar with :class:`StringEnd`\ ().
 
         To report proper column numbers, ``parse_string`` operates on a copy of the input string where all tabs are
         converted to spaces (8 spaces per tab, as per the default in ``string.expandtabs``). If the input string
@@ -1345,7 +1345,7 @@ class ParserElement(ABC):
     def __add__(self, other) -> "ParserElement":
         """
         Implementation of ``+`` operator - returns :class:`And`. Adding strings to a :class:`ParserElement`
-        converts them to :class:`Literal`s by default.
+        converts them to :class:`Literal`\ s by default.
 
         Example::
 
@@ -1427,10 +1427,10 @@ class ParserElement(ABC):
         may also include ``None`` as in:
 
         - ``expr*(n, None)`` or ``expr*(n, )`` is equivalent
-             to ``expr*n + ZeroOrMore(expr)``
-             (read as "at least n instances of ``expr``")
+          to ``expr*n + ZeroOrMore(expr)``
+          (read as "at least n instances of ``expr``")
         - ``expr*(None, n)`` is equivalent to ``expr*(0, n)``
-             (read as "0 to n instances of ``expr``")
+          (read as "0 to n instances of ``expr``")
         - ``expr*(None, None)`` is equivalent to ``ZeroOrMore(expr)``
         - ``expr*(1, None)`` is equivalent to ``OneOrMore(expr)``
 
@@ -1657,7 +1657,7 @@ class ParserElement(ABC):
         If ``name`` is given with a trailing ``'*'`` character, then ``list_all_matches`` will be
         passed as ``True``.
 
-        If ``name` is omitted, same as calling :class:`copy`.
+        If ``name`` is omitted, same as calling :class:`copy`.
 
         Example::
 
@@ -1834,7 +1834,9 @@ class ParserElement(ABC):
     def set_name(self, name: str) -> "ParserElement":
         """
         Define name for this expression, makes debugging and exception messages clearer.
+
         Example::
+
             Word(nums).parse_string("ABC")  # -> Exception: Expected W:(0-9) (at char 0), (line:1, col:1)
             Word(nums).set_name("integer").parse_string("ABC")  # -> Exception: Expected integer (at char 0), (line:1, col:1)
         """

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -467,6 +467,7 @@ def nested_expr(
     closing delimiters (``"("`` and ``")"`` are the default).
 
     Parameters:
+
     - ``opener`` - opening character for a nested list
       (default= ``"("``); can also be a pyparsing expression
     - ``closer`` - closing character for a nested list
@@ -738,6 +739,7 @@ def infix_notation(
     improve your parser performance.
 
     Parameters:
+
     - ``base_expr`` - expression representing the most basic operand to
       be used in the expression
     - ``op_list`` - list of tuples, one for each operator precedence level

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -85,7 +85,7 @@ class ParseResults:
     class List(list):
         """
         Simple wrapper class to distinguish parsed list results that should be preserved
-        as actual Python lists, instead of being converted to :class:`ParseResults`:
+        as actual Python lists, instead of being converted to :class:`ParseResults`::
 
             LBRACK, RBRACK = map(pp.Suppress, "[]")
             element = pp.Forward()
@@ -107,7 +107,7 @@ class ParseResults:
                 (2,3,4)
                 ''', post_parse=lambda s, r: (r[0], type(r[0])))
 
-        prints:
+        prints::
 
             100
             (100, <class 'int'>)


### PR DESCRIPTION
Two warnings remain from the Hebrew and Devanagari names in pyparsing_unicode, but those are due to Sphinx using Python's builtin `re` library to parse identifiers (which does not have thorough Unicode handling for `\w`).