### PR TITLE
Use Literal.__new__ to select optimized subclasses

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -2343,7 +2343,10 @@ class Literal(Token):
     def __copy__(self) -> "Literal":
         # Needed to assist copy.copy() (used in ParserElement.copy), which
         # doesn't handle the factory __new__ well.
-        return Literal(self.match)
+        obj = Literal(self.match)
+        # Copy instance attributes
+        obj.__dict__.update(self.__dict__)
+        return obj
 
     def _generateDefaultName(self) -> str:
         return repr(self.match)

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -2321,7 +2321,7 @@ class Literal(Token):
         match_string = matchString or match_string
         self.match = match_string
         self.matchLen = len(match_string)
-        self.firstMatchChar = match_string[0] if match_string else ''
+        self.firstMatchChar = match_string[:1]
         self.errmsg = "Expected " + self.name
         self.mayReturnEmpty = False
         self.mayIndexError = False

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8907,11 +8907,9 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
 
     def testCreateLiteralWithEmptyString(self):
         # test creating Literal with empty string
-        print('verify non-fatal usage of Literal("")')
-        with self.assertRaises(
-            ValueError, msg="failed to warn use of empty string for Literal"
-        ):
-            e = pp.Literal("")
+        print('verify that Literal("") is optimized to Empty()')
+        e = pp.Literal("")
+        self.assertIsInstance(e, pp.Empty)
 
     def testLineMethodSpecialCaseAtStart(self):
         # test line() behavior when starting at 0 and the opening line is an \n

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6770,6 +6770,13 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         b_keyword = a_keyword.copy()
         self.assertEqual(a_keyword.identChars, b_keyword.identChars)
 
+    def testCopyLiteralAttrs(self):
+        lit = pp.Literal("foo").leave_whitespace()
+        lit2 = lit.copy()
+        self.assertFalse(lit2.skipWhitespace)
+        lit3 = lit2.ignore_whitespace().copy()
+        self.assertTrue(lit3.skipWhitespace)
+
     def testLiteralVsKeyword(self):
 
         integer = ppc.integer


### PR DESCRIPTION
This turns `Literal()` into a factory which creates an object of the appropriate type from the start, rather than having to overwrite the `__class__` attribute later.

See #412 for the suggestion.

Question: should `Empty` be made a subclass of `Literal`?  It seems to make sense that it would be.