### PR TITLE
Meaningful repr for ParserElements

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3749,10 +3749,8 @@ class ParseExpression(ParserElement):
         self.callPreparse = False
 
     def __repr__(self):
-        if not self.exprs:
-            return f"{type(self).__name__}()"
-        if len(self.exprs) == 1:
-            return f"{type(self).__name__}([{self.exprs[0]!r}])"
+        if len(self.exprs) < 2:
+            return f"{type(self).__name__}({self.exprs!r})"
         op = f" {type(self).OPERATOR} "
         return "(" + op.join(map(repr, self.exprs)) + ")"
 
@@ -3957,10 +3955,8 @@ class And(ParseExpression):
         self.callPreparse = True
 
     def __repr__(self):
-        if not self.exprs:
-            return f"{type(self).__name__}()"
-        if len(self.exprs) == 1:
-            return f"{type(self).__name__}([{self.exprs[0]!r}])"
+        if len(self.exprs) < 2:
+            return f"{type(self).__name__}({self.exprs!r})"
 
         builder = [repr(self.exprs[0])]
         nextOp = "+"

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -7,7 +7,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Generator,
+    Iterator,
     List,
     NamedTuple,
     Sequence,
@@ -1193,7 +1193,7 @@ class ParserElement(ABC):
         *,
         debug: bool = False,
         maxMatches: int = _MAX_INT,
-    ) -> Generator[Tuple[ParseResults, int, int], None, None]:
+    ) -> Iterator[Tuple[ParseResults, int, int]]:
         """
         Scan the input string for expression matches.  Each match will return the
         matching tokens, start location, and end location.  May be called with optional
@@ -1367,7 +1367,7 @@ class ParserElement(ABC):
         include_separators: bool = False,
         *,
         includeSeparators=False,
-    ) -> Generator[str, None, None]:
+    ) -> Iterator[str]:
         """
         Generator method to split a string using the given expression as a separator.
         May be called with optional ``maxsplit`` argument, to limit the number of splits;

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3971,6 +3971,8 @@ class And(ParseExpression):
             builder.append(nextOp)
             builder.append(repr(expr))
             nextOp = "+"
+        if nextOp == "-":
+            builder.append("+ _ErrorStop()")
         return "(" + " ".join(builder) + ")"
 
     def streamline(self) -> ParserElement:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3971,7 +3971,7 @@ class And(ParseExpression):
             builder.append(nextOp)
             builder.append(repr(expr))
             nextOp = "+"
-        return " ".join(builder)
+        return "(" + " ".join(builder) + ")"
 
     def streamline(self) -> ParserElement:
         # collapse any _PendingSkip's

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Iterable,
     Iterator,
     List,
     NamedTuple,
@@ -24,7 +25,6 @@ import copy
 import warnings
 import re
 import sys
-from collections.abc import Iterable
 import traceback
 import types
 from operator import itemgetter
@@ -6010,7 +6010,7 @@ def _srange_escape(char: str) -> str:
         return char
     return "\\" + hex(c)
 
-def _gen_srange(chars: list[str]) -> Iterator[str]:
+def _gen_srange(chars: Sequence[str]) -> Iterator[str]:
     # Precondition: s is sorted
     if len(chars) <= 2:
         yield from map(_srange_escape, chars)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5647,6 +5647,8 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         recursive = pp.Forward()
         recursive <<= a + (b + recursive)[...]
 
+        zOpenTag, zCloseTag = pp.makeHTMLTags("Z")
+
         tests = [
             a,
             b,
@@ -5659,8 +5661,10 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             pp.delimitedList(pp.Word(pp.nums).setName("int")),
             pp.countedArray(pp.Word(pp.nums).setName("int")),
             pp.nestedExpr(),
-            pp.makeHTMLTags("Z"),
-            (pp.anyOpenTag, pp.anyCloseTag),
+            zOpenTag,
+            zCloseTag,
+            pp.anyOpenTag,
+            pp.anyCloseTag,
             pp.commonHTMLEntity,
             pp.commonHTMLEntity.setParseAction(pp.replaceHTMLEntity).transformString(
                 "lsdjkf &lt;lsdjkf&gt;&amp;&apos;&quot;&xyzzy;"
@@ -5681,8 +5685,10 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             int [, int]...
             (len) int...
             nested () expression
-            (<Z>, </Z>)
-            (<any tag>, </any tag>)
+            <Z>
+            </Z>
+            <any tag>
+            </any tag>
             common HTML entity
             lsdjkf <lsdjkf>&'"&xyzzy;""".splitlines(),
         )
@@ -9348,30 +9354,30 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                 f"{expected_function!r} not found in ParseException.explain()",
             )
 
-    def testExpressionDefaultStrings(self):
+    def testWordCharDefaultStrings(self):
         expr = pp.Word(pp.nums)
         print(expr)
-        self.assertEqual("W:(0-9)", repr(expr))
+        self.assertEqual("W:(0-9)", str(expr))
 
         expr = pp.Word(pp.nums, exact=3)
         print(expr)
-        self.assertEqual("W:(0-9){3}", repr(expr))
+        self.assertEqual("W:(0-9){3}", str(expr))
 
         expr = pp.Word(pp.nums, min=2)
         print(expr)
-        self.assertEqual("W:(0-9){2,...}", repr(expr))
+        self.assertEqual("W:(0-9){2,...}", str(expr))
 
         expr = pp.Word(pp.nums, max=3)
         print(expr)
-        self.assertEqual("W:(0-9){1,3}", repr(expr))
+        self.assertEqual("W:(0-9){1,3}", str(expr))
 
         expr = pp.Word(pp.nums, min=2, max=3)
         print(expr)
-        self.assertEqual("W:(0-9){2,3}", repr(expr))
+        self.assertEqual("W:(0-9){2,3}", str(expr))
 
         expr = pp.Char(pp.nums)
         print(expr)
-        self.assertEqual("(0-9)", repr(expr))
+        self.assertEqual("(0-9)", str(expr))
 
     def testEmptyExpressionsAreHandledProperly(self):
         from pyparsing.diagram import to_railroad


### PR DESCRIPTION
See #416 for discussion.

Populated instances of `Forward` are represented only as `"Forward(...)"` to prevent infinite recursion.  I don't imagine this changing.

Helper classes like `_PendingSkip` and `_ErrorStop` are not yet handled, and there is no special handling for `Literal`.  I'll ask about these in the issue.

I held off on creating unit tests for the new implementations to let the devs decide whether `__repr__()` actually belongs in the test suite or not.