### PR TITLE
Fix set_debug variable name in documentation

### DIFF
--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -457,7 +457,7 @@ methods for code to use are:
   repeatedly to specify multiple expressions; useful to specify
   patterns of comment syntax, for example
 
-- ``set_debug(debug_flag=True)`` - function to enable/disable tracing output
+- ``set_debug(flag=True)`` - function to enable/disable tracing output
   when trying to match this element
 
 - ``validate()`` - function to verify that the defined grammar does not


### PR DESCRIPTION
Update the documentation for `set_debug` to have the correct variable name of `flag`