### PR TITLE
Copy expression in ParseElementEnhance on ignoring

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4517,11 +4517,11 @@ class ParseElementEnhance(ParserElement):
             if other not in self.ignoreExprs:
                 super().ignore(other)
                 if self.expr is not None:
-                    self.expr.ignore(self.ignoreExprs[-1])
+                    self.expr = self.expr.copy().ignore(self.ignoreExprs[-1])
         else:
             super().ignore(other)
             if self.expr is not None:
-                self.expr.ignore(self.ignoreExprs[-1])
+                self.expr = self.expr.copy().ignore(self.ignoreExprs[-1])
         return self
 
     def streamline(self) -> ParserElement:


### PR DESCRIPTION
To avoid the side effect that a pattern set to be ignored in one expression gets ignored everywhere else.

I didn't open an issue, since the problem and the fix seemed pretty trivial.

BTW, `leave_whitespace` and `ignore_whitespace` first make a copy, and then check for `None`. I don't think that's correct:

https://github.com/pyparsing/pyparsing/blob/d93930308f7fe79f2290812074f62a472c83db59/pyparsing/core.py#L4501-L4502


