### PR TITLE
Removed unused keyword var in lucene_grammar.py

### DIFF
--- a/examples/lucene_grammar.py
+++ b/examples/lucene_grammar.py
@@ -15,7 +15,6 @@ pp.ParserElement.enablePackrat()
 COLON, LBRACK, RBRACK, LBRACE, RBRACE, TILDE, CARAT = map(pp.Literal, ":[]{}~^")
 LPAR, RPAR = map(pp.Suppress, "()")
 and_, or_, not_, to_ = map(pp.CaselessKeyword, "AND OR NOT TO".split())
-keyword = and_ | or_ | not_ | to_
 
 expression = pp.Forward()
 

--- a/examples/lucene_grammar.py
+++ b/examples/lucene_grammar.py
@@ -15,6 +15,7 @@ pp.ParserElement.enablePackrat()
 COLON, LBRACK, RBRACK, LBRACE, RBRACE, TILDE, CARAT = map(pp.Literal, ":[]{}~^")
 LPAR, RPAR = map(pp.Suppress, "()")
 and_, or_, not_, to_ = map(pp.CaselessKeyword, "AND OR NOT TO".split())
+keyword = and_ | or_ | not_ | to_
 
 expression = pp.Forward()
 
@@ -44,7 +45,8 @@ boost = CARAT - number("boost")
 string_expr = pp.Group(string + proximity_modifier) | string
 word_expr = pp.Group(valid_word + fuzzy_modifier) | valid_word
 term << (
-    pp.Optional(field_name("field") + COLON)
+    ~keyword
+    + pp.Optional(field_name("field") + COLON)
     + (word_expr | string_expr | range_search | pp.Group(LPAR + expression + RPAR))
     + pp.Optional(boost)
 )


### PR DESCRIPTION
Found a variable in the `lucene_grammar.py` example which is not being used, I have removed it to keep things clean