### PR TITLE
Simplify the `_trim_arity` function

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -33,6 +33,7 @@ from operator import itemgetter
 from functools import wraps
 from threading import RLock
 from pathlib import Path
+import inspect
 
 from .util import (
     _FifoCache,
@@ -267,53 +268,24 @@ printables = "".join([c for c in string.printable if c not in string.whitespace]
 _trim_arity_call_line: traceback.StackSummary = None  # type: ignore[assignment]
 
 
-def _trim_arity(func, max_limit=3):
+def _trim_arity(func: Callable, max_limit: int = 3):
     """decorator to trim function calls to match the arity of the target"""
     global _trim_arity_call_line
 
     if func in _single_arg_builtins:
         return lambda s, l, t: func(t)
 
-    limit = 0
-    found_arity = False
+    func_signature = inspect.signature(func)
+    func_arguments_count = len(func_signature.parameters)
 
-    # synthesize what would be returned by traceback.extract_stack at the call to
-    # user's parse action 'func', so that we don't incur call penalty at parse time
+    if max_limit < func_arguments_count:
+        raise TypeError(f"Function accept more then `max_limit` arguments. "
+                        f"Expect no more then {max_limit} but got {func_arguments_count}")
 
-    # fmt: off
-    LINE_DIFF = 7
-    # IF ANY CODE CHANGES, EVEN JUST COMMENTS OR BLANK LINES, BETWEEN THE NEXT LINE AND
-    # THE CALL TO FUNC INSIDE WRAPPER, LINE_DIFF MUST BE MODIFIED!!!!
-    _trim_arity_call_line = (_trim_arity_call_line or traceback.extract_stack(limit=2)[-1])
-    pa_call_line_synth = (_trim_arity_call_line[0], _trim_arity_call_line[1] + LINE_DIFF)
+    limit = max_limit - func_arguments_count
 
     def wrapper(*args):
-        nonlocal found_arity, limit
-        while 1:
-            try:
-                ret = func(*args[limit:])
-                found_arity = True
-                return ret
-            except TypeError as te:
-                # re-raise TypeErrors if they did not come from our arity testing
-                if found_arity:
-                    raise
-                else:
-                    tb = te.__traceback__
-                    frames = traceback.extract_tb(tb, limit=2)
-                    frame_summary = frames[-1]
-                    trim_arity_type_error = (
-                        [frame_summary[:2]][-1][:2] == pa_call_line_synth
-                    )
-                    del tb
-
-                    if trim_arity_type_error:
-                        if limit < max_limit:
-                            limit += 1
-                            continue
-
-                    raise
-    # fmt: on
+        return func(*args[limit:])
 
     # copy func name to wrapper for sensible debug output
     # (can't use functools.wraps, since that messes with function signature)
@@ -322,7 +294,6 @@ def _trim_arity(func, max_limit=3):
     wrapper.__doc__ = func.__doc__
 
     return wrapper
-
 
 def condition_as_parse_action(
     fn: ParseCondition, message: typing.Optional[str] = None, fatal: bool = False


### PR DESCRIPTION
Use inspect module for getting arg count and then calculate the limit value instead of do brute force.