### PR TITLE
Fix railroad so head, body args included in html

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -2232,10 +2232,10 @@ class ParserElement(ABC):
         )
         if isinstance(output_html, (str, Path)):
             with open(output_html, "w", encoding="utf-8") as diag_file:
-                diag_file.write(railroad_to_html(railroad, embed=embed))
+                diag_file.write(railroad_to_html(railroad, embed=embed, **kwargs))
         else:
             # we were passed a file-like object, just write to it
-            output_html.write(railroad_to_html(railroad, embed=embed))
+            output_html.write(railroad_to_html(railroad, embed=embed, **kwargs))
 
     # Compatibility synonyms
     # fmt: off


### PR DESCRIPTION
Minor fix in the railroad diagram code.  Output wasn't getting the railroad.css styling. Attempts to include using this

```
style = """ # css styling """
...
# PEG definitions
statement = ....
....
statement.create_diagram("railroad_diagram_demo.html", vertical=6, show_results_names=True, embed=True, head=style)
```
failed.  `railroad_diagram_demo.html` had no styling added except for what was in the template.

Noticed that  `**kwargs` weren't being passed through to the template.

Added `**kwargs` in for the fix. 

