### PR TITLE
Add CSS to Railroad output

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -2232,10 +2232,10 @@ class ParserElement(ABC):
         )
         if isinstance(output_html, (str, Path)):
             with open(output_html, "w", encoding="utf-8") as diag_file:
-                diag_file.write(railroad_to_html(railroad, embed=embed))
+                diag_file.write(railroad_to_html(railroad, embed=embed, **kwargs))
         else:
             # we were passed a file-like object, just write to it
-            output_html.write(railroad_to_html(railroad, embed=embed))
+            output_html.write(railroad_to_html(railroad, embed=embed, **kwargs))
 
     # Compatibility synonyms
     # fmt: off

--- a/pyparsing/diagram/__init__.py
+++ b/pyparsing/diagram/__init__.py
@@ -145,7 +145,8 @@ def railroad_to_html(diagrams: List[NamedDiagram], embed=False, **kwargs) -> str
             continue
         io = StringIO()
         try:
-            diagram.diagram.writeStandalone(io.write)
+            css = kwargs.get('css')
+            diagram.diagram.writeStandalone(io.write, css=css)
         except AttributeError:
             diagram.diagram.writeSvg(io.write)
         title = diagram.name


### PR DESCRIPTION
The `head` kwargs wasn't getting passed on the HTML file.  Also the railroad `diagram.diagram.writeStandalone` function adds the default styling to each instance of the diagram this needed to be turned off so that any style sheet include via the `head` arg has an effect.  Fund this while testing.

Sample to test PR
```python
from pyparsing import Word, alphas, restOfLine
# Creates a simple diagram with a blue body and
# various other railroad features colored with
# a complete disregard for taste

# Very simple grammer for demo purposes
salutation = Word(alphas).setResultsName("salutation")
subject = restOfLine.setResultsName("subject")

parse_grammer = salutation + subject

# This is used to turn off the railroads
# definition of DEFAULT_STYLE.
# If this is set to 'None' the default style
# will be written as part of each diagram
# and you will not be able to set the 
# css style globally and the string 'expStyle'
# will have no effect.
# There is probably a PR to railroad_diagram to
# remove some cruft left in the SVG.
DEFAULT_STYLE = ""

# CSS Code to be placed into head of the html file
expStyle = """
<style type="text/css">

body {
    background-color: blue;
}

.railroad-heading {
    font-family: monospace;
    color: bisque;
}

svg.railroad-diagram {
    background-color: hsl(264,45%,85%);
}
svg.railroad-diagram path {
    stroke-width: 3;
    stroke: green;
    fill: rgba(0,0,0,0);
}
svg.railroad-diagram text {
    font: bold 14px monospace;
    text-anchor: middle;
    white-space: pre;
}
svg.railroad-diagram text.diagram-text {
    font-size: 12px;
}
svg.railroad-diagram text.diagram-arrow {
    font-size: 16px;
}
svg.railroad-diagram text.label {
    text-anchor: start;
}
svg.railroad-diagram text.comment {
    font: italic 12px monospace;
}
svg.railroad-diagram g.non-terminal text {
    /*font-style: italic;*/
}
svg.railroad-diagram rect {
    stroke-width: 3;
    stroke: black;
    fill: hsl(55, 72%, 69%);
}
svg.railroad-diagram rect.group-box {
    stroke: rgb(33, 8, 225);
    stroke-dasharray: 10 5;
    fill: none;
}
svg.railroad-diagram path.diagram-text {
    stroke-width: 3;
    stroke: black;
    fill: white;
    cursor: help;
}
svg.railroad-diagram g.diagram-text:hover path.diagram-text {
    fill: #eee;
}
</style>
"""

# the 'css=DEFAULT_STYLE' or 'css=""' is needed to turn off railroad_diagrams styling
parse_grammer.create_diagram("railroad_diagram_demo.html", vertical=6, show_results_names=True, css=DEFAULT_STYLE, head=expStyle)
```
