### PR TITLE
Limit error message overriding

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4547,7 +4547,8 @@ class ParseElementEnhance(ParserElement):
             try:
                 return self.expr._parse(instring, loc, doActions, callPreParse=False)
             except ParseBaseException as pbe:
-                pbe.msg = self.errmsg
+                if not isinstance(self, Forward) or self.customName is not None:
+                    pbe.msg = self.errmsg
                 raise
         else:
             raise ParseException(instring, loc, "No expression defined", self)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9884,6 +9884,29 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                 msg=f"unexpected exception line ({exception_line!r})",
             )
 
+
+    def testForwardReferenceException(self):
+        token = pp.Forward()
+        num = pp.Word(pp.nums)
+        num.setName("num")
+        text = pp.Word(pp.alphas)
+        text.setName("text")
+        fail = pp.Regex(r"\\[A-Za-z]*")("name")
+        def parse_fail(s, loc, toks):
+            raise pp.ParseFatalException(s, loc, f"Unknown symbol: {toks['name']}")
+        fail.set_parse_action(parse_fail)
+        token <<= num | text | fail
+
+        # If no name is given, do not intercept error messages
+        with self.assertRaises(pp.ParseFatalException, msg="Unknown symbol: \\fail"):
+            token.parse_string("\\fail")
+
+        # If name is given, do intercept error messages
+        token.set_name("token")
+        with self.assertRaises(pp.ParseFatalException, msg="Expected token, found.*"):
+            token.parse_string("\\fail")
+
+
     def testMiscellaneousExceptionBits(self):
         pp.ParserElement.verbose_stacktrace = True
 


### PR DESCRIPTION
This is a continuation from the conversation in matplotlib/matplotlib#26152.

I'm opening this here to further the conversation and so we can talk in slightly more concrete terms.

This is based on my last suggestion in that thread where I suggested Forward references without a name do not override the error message.

Either one of these factors or another error message override flag would be sufficient for matplotlib's purposes, so if you feel that this could be broader or would prefer to introduce a more explicit test, then feel free to say so and I will try to do so.

