### PR TITLE
Allow `int` or `None` for `cache_size_limit` to `enable_packrat`.

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1079,7 +1079,7 @@ class ParserElement(ABC):
         ParserElement._left_recursion_enabled = True
 
     @staticmethod
-    def enable_packrat(cache_size_limit: int = 128, *, force: bool = False) -> None:
+    def enable_packrat(cache_size_limit: Union[int, None] = 128, *, force: bool = False) -> None:
         """
         Enables "packrat" parsing, which adds memoizing to the parsing logic.
         Repeated parse attempts at the same string location (which happens


### PR DESCRIPTION
This should close https://github.com/pyparsing/pyparsing/issues/498.