### PR TITLE
Fix pep8 compatibility code (fixes #501)

### DIFF
--- a/pyparsing/actions.py
+++ b/pyparsing/actions.py
@@ -1,7 +1,7 @@
 # actions.py
 
 from .exceptions import ParseException
-from .util import col, replaced_by_pep8
+from .util import _make_synonym_function, col
 
 
 class OnlyOnce:
@@ -199,19 +199,9 @@ def with_class(classname, namespace=""):
 
 # pre-PEP8 compatibility symbols
 # fmt: off
-@replaced_by_pep8(replace_with)
-def replaceWith(): ...
-
-@replaced_by_pep8(remove_quotes)
-def removeQuotes(): ...
-
-@replaced_by_pep8(with_attribute)
-def withAttribute(): ...
-
-@replaced_by_pep8(with_class)
-def withClass(): ...
-
-@replaced_by_pep8(match_only_at_col)
-def matchOnlyAtCol(): ...
-
+replaceWith = _make_synonym_function("replaceWith", replace_with)
+removeQuotes = _make_synonym_function("removeQuotes", remove_quotes)
+withAttribute = _make_synonym_function("withAttribute", with_attribute)
+withClass = _make_synonym_function("withClass", with_class)
+matchOnlyAtCol = _make_synonym_function("matchOnlyAtCol", match_only_at_col)
 # fmt: on

--- a/pyparsing/actions.py
+++ b/pyparsing/actions.py
@@ -1,7 +1,7 @@
 # actions.py
 
 from .exceptions import ParseException
-from .util import _make_synonym_function, col
+from .util import col, replaced_by_pep8
 
 
 class OnlyOnce:
@@ -199,9 +199,9 @@ def with_class(classname, namespace=""):
 
 # pre-PEP8 compatibility symbols
 # fmt: off
-replaceWith = _make_synonym_function("replaceWith", replace_with)
-removeQuotes = _make_synonym_function("removeQuotes", remove_quotes)
-withAttribute = _make_synonym_function("withAttribute", with_attribute)
-withClass = _make_synonym_function("withClass", with_class)
-matchOnlyAtCol = _make_synonym_function("matchOnlyAtCol", match_only_at_col)
+replaceWith = replaced_by_pep8("replaceWith", replace_with)
+removeQuotes = replaced_by_pep8("removeQuotes", remove_quotes)
+withAttribute = replaced_by_pep8("withAttribute", with_attribute)
+withClass = replaced_by_pep8("withClass", with_class)
+matchOnlyAtCol = replaced_by_pep8("matchOnlyAtCol", match_only_at_col)
 # fmt: on

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -41,9 +41,9 @@ from .util import (
     _escape_regex_range_chars,
     _bslash,
     _flatten,
+    _make_synonym_function,
     LRUMemo as _LRUMemo,
     UnboundedMemo as _UnboundedMemo,
-    replaced_by_pep8,
 )
 from .exceptions import *
 from .actions import *
@@ -2253,82 +2253,32 @@ class ParserElement(ABC):
 
     # Compatibility synonyms
     # fmt: off
-    @staticmethod
-    @replaced_by_pep8(inline_literals_using)
-    def inlineLiteralsUsing(): ...
-
-    @staticmethod
-    @replaced_by_pep8(set_default_whitespace_chars)
-    def setDefaultWhitespaceChars(): ...
-
-    @replaced_by_pep8(set_results_name)
-    def setResultsName(self): ...
-
-    @replaced_by_pep8(set_break)
-    def setBreak(self): ...
-
-    @replaced_by_pep8(set_parse_action)
-    def setParseAction(self): ...
-
-    @replaced_by_pep8(add_parse_action)
-    def addParseAction(self): ...
-
-    @replaced_by_pep8(add_condition)
-    def addCondition(self): ...
-
-    @replaced_by_pep8(set_fail_action)
-    def setFailAction(self): ...
-
-    @replaced_by_pep8(try_parse)
-    def tryParse(self): ...
-
-    @staticmethod
-    @replaced_by_pep8(enable_left_recursion)
-    def enableLeftRecursion(): ...
-
-    @staticmethod
-    @replaced_by_pep8(enable_packrat)
-    def enablePackrat(): ...
-
-    @replaced_by_pep8(parse_string)
-    def parseString(self): ...
-
-    @replaced_by_pep8(scan_string)
-    def scanString(self): ...
-
-    @replaced_by_pep8(transform_string)
-    def transformString(self): ...
-
-    @replaced_by_pep8(search_string)
-    def searchString(self): ...
-
-    @replaced_by_pep8(ignore_whitespace)
-    def ignoreWhitespace(self): ...
-
-    @replaced_by_pep8(leave_whitespace)
-    def leaveWhitespace(self): ...
-
-    @replaced_by_pep8(set_whitespace_chars)
-    def setWhitespaceChars(self): ...
-
-    @replaced_by_pep8(parse_with_tabs)
-    def parseWithTabs(self): ...
-
-    @replaced_by_pep8(set_debug_actions)
-    def setDebugActions(self): ...
-
-    @replaced_by_pep8(set_debug)
-    def setDebug(self): ...
-
-    @replaced_by_pep8(set_name)
-    def setName(self): ...
-
-    @replaced_by_pep8(parse_file)
-    def parseFile(self): ...
-
-    @replaced_by_pep8(run_tests)
-    def runTests(self): ...
-
+    inlineLiteralsUsing = _make_synonym_function("inlineLiteralsUsing", inline_literals_using)
+    setDefaultWhitespaceChars = _make_synonym_function(
+        "setDefaultWhitespaceChars", set_default_whitespace_chars
+    )
+    setResultsName = _make_synonym_function("setResultsName", set_results_name)
+    setBreak = _make_synonym_function("setBreak", set_break)
+    setParseAction = _make_synonym_function("setParseAction", set_parse_action)
+    addParseAction = _make_synonym_function("addParseAction", add_parse_action)
+    addCondition = _make_synonym_function("addCondition", add_condition)
+    setFailAction = _make_synonym_function("setFailAction", set_fail_action)
+    tryParse = _make_synonym_function("tryParse", try_parse)
+    enableLeftRecursion = _make_synonym_function("enableLeftRecursion", enable_left_recursion)
+    enablePackrat = _make_synonym_function("enablePackrat", enable_packrat)
+    parseString = _make_synonym_function("parseString", parse_string)
+    scanString = _make_synonym_function("scanString", scan_string)
+    transformString = _make_synonym_function("transformString", transform_string)
+    searchString = _make_synonym_function("searchString", search_string)
+    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
+    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
+    setWhitespaceChars = _make_synonym_function("setWhitespaceChars", set_whitespace_chars)
+    parseWithTabs = _make_synonym_function("parseWithTabs", parse_with_tabs)
+    setDebugActions = _make_synonym_function("setDebugActions", set_debug_actions)
+    setDebug = _make_synonym_function("setDebug", set_debug)
+    setName = _make_synonym_function("setName", set_name)
+    parseFile = _make_synonym_function("parseFile", parse_file)
+    runTests = _make_synonym_function("runTests", run_tests)
     canParseNext = can_parse_next
     resetCache = reset_cache
     defaultName = default_name
@@ -3911,11 +3861,8 @@ class ParseExpression(ParserElement):
 
     # Compatibility synonyms
     # fmt: off
-    @replaced_by_pep8(leave_whitespace)
-    def leaveWhitespace(self): ...
-
-    @replaced_by_pep8(ignore_whitespace)
-    def ignoreWhitespace(self): ...
+    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
+    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
     # fmt: on
 
 
@@ -4635,11 +4582,8 @@ class ParseElementEnhance(ParserElement):
 
     # Compatibility synonyms
     # fmt: off
-    @replaced_by_pep8(leave_whitespace)
-    def leaveWhitespace(self): ...
-
-    @replaced_by_pep8(ignore_whitespace)
-    def ignoreWhitespace(self): ...
+    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
+    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
     # fmt: on
 
 
@@ -5666,11 +5610,8 @@ class Forward(ParseElementEnhance):
 
     # Compatibility synonyms
     # fmt: off
-    @replaced_by_pep8(leave_whitespace)
-    def leaveWhitespace(self): ...
-
-    @replaced_by_pep8(ignore_whitespace)
-    def ignoreWhitespace(self): ...
+    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
+    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
     # fmt: on
 
 
@@ -6144,16 +6085,8 @@ lineStart = line_start
 lineEnd = line_end
 stringStart = string_start
 stringEnd = string_end
-
-@replaced_by_pep8(null_debug_action)
-def nullDebugAction(): ...
-
-@replaced_by_pep8(trace_parse_action)
-def traceParseAction(): ...
-
-@replaced_by_pep8(condition_as_parse_action)
-def conditionAsParseAction(): ...
-
-@replaced_by_pep8(token_map)
-def tokenMap(): ...
+nullDebugAction = _make_synonym_function("nullDebugAction", null_debug_action)
+traceParseAction = _make_synonym_function("traceParseAction", trace_parse_action)
+conditionAsParseAction = _make_synonym_function("conditionAsParseAction", condition_as_parse_action)
+tokenMap = _make_synonym_function("tokenMap", token_map)
 # fmt: on

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -41,9 +41,9 @@ from .util import (
     _escape_regex_range_chars,
     _bslash,
     _flatten,
-    _make_synonym_function,
     LRUMemo as _LRUMemo,
     UnboundedMemo as _UnboundedMemo,
+    replaced_by_pep8,
 )
 from .exceptions import *
 from .actions import *
@@ -2253,32 +2253,32 @@ class ParserElement(ABC):
 
     # Compatibility synonyms
     # fmt: off
-    inlineLiteralsUsing = _make_synonym_function("inlineLiteralsUsing", inline_literals_using)
-    setDefaultWhitespaceChars = _make_synonym_function(
+    inlineLiteralsUsing = replaced_by_pep8("inlineLiteralsUsing", inline_literals_using)
+    setDefaultWhitespaceChars = replaced_by_pep8(
         "setDefaultWhitespaceChars", set_default_whitespace_chars
     )
-    setResultsName = _make_synonym_function("setResultsName", set_results_name)
-    setBreak = _make_synonym_function("setBreak", set_break)
-    setParseAction = _make_synonym_function("setParseAction", set_parse_action)
-    addParseAction = _make_synonym_function("addParseAction", add_parse_action)
-    addCondition = _make_synonym_function("addCondition", add_condition)
-    setFailAction = _make_synonym_function("setFailAction", set_fail_action)
-    tryParse = _make_synonym_function("tryParse", try_parse)
-    enableLeftRecursion = _make_synonym_function("enableLeftRecursion", enable_left_recursion)
-    enablePackrat = _make_synonym_function("enablePackrat", enable_packrat)
-    parseString = _make_synonym_function("parseString", parse_string)
-    scanString = _make_synonym_function("scanString", scan_string)
-    transformString = _make_synonym_function("transformString", transform_string)
-    searchString = _make_synonym_function("searchString", search_string)
-    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
-    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
-    setWhitespaceChars = _make_synonym_function("setWhitespaceChars", set_whitespace_chars)
-    parseWithTabs = _make_synonym_function("parseWithTabs", parse_with_tabs)
-    setDebugActions = _make_synonym_function("setDebugActions", set_debug_actions)
-    setDebug = _make_synonym_function("setDebug", set_debug)
-    setName = _make_synonym_function("setName", set_name)
-    parseFile = _make_synonym_function("parseFile", parse_file)
-    runTests = _make_synonym_function("runTests", run_tests)
+    setResultsName = replaced_by_pep8("setResultsName", set_results_name)
+    setBreak = replaced_by_pep8("setBreak", set_break)
+    setParseAction = replaced_by_pep8("setParseAction", set_parse_action)
+    addParseAction = replaced_by_pep8("addParseAction", add_parse_action)
+    addCondition = replaced_by_pep8("addCondition", add_condition)
+    setFailAction = replaced_by_pep8("setFailAction", set_fail_action)
+    tryParse = replaced_by_pep8("tryParse", try_parse)
+    enableLeftRecursion = replaced_by_pep8("enableLeftRecursion", enable_left_recursion)
+    enablePackrat = replaced_by_pep8("enablePackrat", enable_packrat)
+    parseString = replaced_by_pep8("parseString", parse_string)
+    scanString = replaced_by_pep8("scanString", scan_string)
+    transformString = replaced_by_pep8("transformString", transform_string)
+    searchString = replaced_by_pep8("searchString", search_string)
+    ignoreWhitespace = replaced_by_pep8("ignoreWhitespace", ignore_whitespace)
+    leaveWhitespace = replaced_by_pep8("leaveWhitespace", leave_whitespace)
+    setWhitespaceChars = replaced_by_pep8("setWhitespaceChars", set_whitespace_chars)
+    parseWithTabs = replaced_by_pep8("parseWithTabs", parse_with_tabs)
+    setDebugActions = replaced_by_pep8("setDebugActions", set_debug_actions)
+    setDebug = replaced_by_pep8("setDebug", set_debug)
+    setName = replaced_by_pep8("setName", set_name)
+    parseFile = replaced_by_pep8("parseFile", parse_file)
+    runTests = replaced_by_pep8("runTests", run_tests)
     canParseNext = can_parse_next
     resetCache = reset_cache
     defaultName = default_name
@@ -3861,8 +3861,8 @@ class ParseExpression(ParserElement):
 
     # Compatibility synonyms
     # fmt: off
-    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
-    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
+    leaveWhitespace = replaced_by_pep8("leaveWhitespace", leave_whitespace)
+    ignoreWhitespace = replaced_by_pep8("ignoreWhitespace", ignore_whitespace)
     # fmt: on
 
 
@@ -4582,8 +4582,8 @@ class ParseElementEnhance(ParserElement):
 
     # Compatibility synonyms
     # fmt: off
-    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
-    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
+    leaveWhitespace = replaced_by_pep8("leaveWhitespace", leave_whitespace)
+    ignoreWhitespace = replaced_by_pep8("ignoreWhitespace", ignore_whitespace)
     # fmt: on
 
 
@@ -5610,8 +5610,8 @@ class Forward(ParseElementEnhance):
 
     # Compatibility synonyms
     # fmt: off
-    leaveWhitespace = _make_synonym_function("leaveWhitespace", leave_whitespace)
-    ignoreWhitespace = _make_synonym_function("ignoreWhitespace", ignore_whitespace)
+    leaveWhitespace = replaced_by_pep8("leaveWhitespace", leave_whitespace)
+    ignoreWhitespace = replaced_by_pep8("ignoreWhitespace", ignore_whitespace)
     # fmt: on
 
 
@@ -6085,8 +6085,8 @@ lineStart = line_start
 lineEnd = line_end
 stringStart = string_start
 stringEnd = string_end
-nullDebugAction = _make_synonym_function("nullDebugAction", null_debug_action)
-traceParseAction = _make_synonym_function("traceParseAction", trace_parse_action)
-conditionAsParseAction = _make_synonym_function("conditionAsParseAction", condition_as_parse_action)
-tokenMap = _make_synonym_function("tokenMap", token_map)
+nullDebugAction = replaced_by_pep8("nullDebugAction", null_debug_action)
+traceParseAction = replaced_by_pep8("traceParseAction", trace_parse_action)
+conditionAsParseAction = replaced_by_pep8("conditionAsParseAction", condition_as_parse_action)
+tokenMap = replaced_by_pep8("tokenMap", token_map)
 # fmt: on

--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -9,7 +9,7 @@ from .util import (
     line,
     lineno,
     _collapse_string_to_ranges,
-    _make_synonym_function,
+    replaced_by_pep8,
 )
 from .unicode import pyparsing_unicode as ppu
 
@@ -244,7 +244,7 @@ class ParseBaseException(Exception):
         return self.explain_exception(self, depth)
 
     # fmt: off
-    markInputline =_make_synonym_function("markInputline", mark_input_line)
+    markInputline = replaced_by_pep8("markInputline", mark_input_line)
     # fmt: on
 
 

--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -9,7 +9,7 @@ from .util import (
     line,
     lineno,
     _collapse_string_to_ranges,
-    replaced_by_pep8,
+    _make_synonym_function,
 )
 from .unicode import pyparsing_unicode as ppu
 
@@ -244,8 +244,7 @@ class ParseBaseException(Exception):
         return self.explain_exception(self, depth)
 
     # fmt: off
-    @replaced_by_pep8(mark_input_line)
-    def markInputline(self): ...
+    markInputline =_make_synonym_function("markInputline", mark_input_line)
     # fmt: on
 
 

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -10,7 +10,7 @@ from .util import (
     _bslash,
     _flatten,
     _escape_regex_range_chars,
-    replaced_by_pep8,
+    _make_synonym_function,
 )
 
 
@@ -1058,43 +1058,17 @@ dblSlashComment = dbl_slash_comment
 cppStyleComment = cpp_style_comment
 javaStyleComment = java_style_comment
 pythonStyleComment = python_style_comment
-
-@replaced_by_pep8(DelimitedList)
-def delimitedList(): ...
-
-@replaced_by_pep8(DelimitedList)
-def delimited_list(): ...
-
-@replaced_by_pep8(counted_array)
-def countedArray(): ...
-
-@replaced_by_pep8(match_previous_literal)
-def matchPreviousLiteral(): ...
-
-@replaced_by_pep8(match_previous_expr)
-def matchPreviousExpr(): ...
-
-@replaced_by_pep8(one_of)
-def oneOf(): ...
-
-@replaced_by_pep8(dict_of)
-def dictOf(): ...
-
-@replaced_by_pep8(original_text_for)
-def originalTextFor(): ...
-
-@replaced_by_pep8(nested_expr)
-def nestedExpr(): ...
-
-@replaced_by_pep8(make_html_tags)
-def makeHTMLTags(): ...
-
-@replaced_by_pep8(make_xml_tags)
-def makeXMLTags(): ...
-
-@replaced_by_pep8(replace_html_entity)
-def replaceHTMLEntity(): ...
-
-@replaced_by_pep8(infix_notation)
-def infixNotation(): ...
+delimitedList = _make_synonym_function("delimitedList", DelimitedList)
+delimited_list = _make_synonym_function("delimited_list", DelimitedList)
+countedArray = _make_synonym_function("countedArray", counted_array)
+matchPreviousLiteral = _make_synonym_function("matchPreviousLiteral", match_previous_literal)
+matchPreviousExpr = _make_synonym_function("matchPreviousExpr", match_previous_expr)
+oneOf = _make_synonym_function("oneOf", one_of)
+dictOf = _make_synonym_function("dictOf", dict_of)
+originalTextFor = _make_synonym_function("originalTextFor", original_text_for)
+nestedExpr = _make_synonym_function("nestedExpr", nested_expr)
+makeHTMLTags = _make_synonym_function("makeHTMLTags", make_html_tags)
+makeXMLTags = _make_synonym_function("makeXMLTags", make_xml_tags)
+replaceHTMLEntity = _make_synonym_function("replaceHTMLEntity", replace_html_entity)
+infixNotation = _make_synonym_function("infixNotation", infix_notation)
 # fmt: on

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -10,7 +10,7 @@ from .util import (
     _bslash,
     _flatten,
     _escape_regex_range_chars,
-    _make_synonym_function,
+    replaced_by_pep8,
 )
 
 
@@ -1058,17 +1058,17 @@ dblSlashComment = dbl_slash_comment
 cppStyleComment = cpp_style_comment
 javaStyleComment = java_style_comment
 pythonStyleComment = python_style_comment
-delimitedList = _make_synonym_function("delimitedList", DelimitedList)
-delimited_list = _make_synonym_function("delimited_list", DelimitedList)
-countedArray = _make_synonym_function("countedArray", counted_array)
-matchPreviousLiteral = _make_synonym_function("matchPreviousLiteral", match_previous_literal)
-matchPreviousExpr = _make_synonym_function("matchPreviousExpr", match_previous_expr)
-oneOf = _make_synonym_function("oneOf", one_of)
-dictOf = _make_synonym_function("dictOf", dict_of)
-originalTextFor = _make_synonym_function("originalTextFor", original_text_for)
-nestedExpr = _make_synonym_function("nestedExpr", nested_expr)
-makeHTMLTags = _make_synonym_function("makeHTMLTags", make_html_tags)
-makeXMLTags = _make_synonym_function("makeXMLTags", make_xml_tags)
-replaceHTMLEntity = _make_synonym_function("replaceHTMLEntity", replace_html_entity)
-infixNotation = _make_synonym_function("infixNotation", infix_notation)
+delimitedList = replaced_by_pep8("delimitedList", DelimitedList)
+delimited_list = replaced_by_pep8("delimited_list", DelimitedList)
+countedArray = replaced_by_pep8("countedArray", counted_array)
+matchPreviousLiteral = replaced_by_pep8("matchPreviousLiteral", match_previous_literal)
+matchPreviousExpr = replaced_by_pep8("matchPreviousExpr", match_previous_expr)
+oneOf = replaced_by_pep8("oneOf", one_of)
+dictOf = replaced_by_pep8("dictOf", dict_of)
+originalTextFor = replaced_by_pep8("originalTextFor", original_text_for)
+nestedExpr = replaced_by_pep8("nestedExpr", nested_expr)
+makeHTMLTags = replaced_by_pep8("makeHTMLTags", make_html_tags)
+makeXMLTags = replaced_by_pep8("makeXMLTags", make_xml_tags)
+replaceHTMLEntity = replaced_by_pep8("replaceHTMLEntity", replace_html_entity)
+infixNotation = replaced_by_pep8("infixNotation", infix_notation)
 # fmt: on

--- a/pyparsing/util.py
+++ b/pyparsing/util.py
@@ -237,7 +237,7 @@ def _flatten(ll: list) -> list:
     return ret
 
 
-def _make_synonym_function(compat_name: str, fn: C) -> C:
+def replaced_by_pep8(compat_name: str, fn: C) -> C:
     # In a future version, uncomment the code in the internal _inner() functions
     # to begin emitting DeprecationWarnings.
 
@@ -251,7 +251,7 @@ def _make_synonym_function(compat_name: str, fn: C) -> C:
         @wraps(fn)
         def _inner(self, *args, **kwargs):
             # warnings.warn(
-            #     f"Deprecated - use {fn.__name__}", DeprecationWarning, stacklevel=3
+            #     f"Deprecated - use {fn.__name__}", DeprecationWarning, stacklevel=2
             # )
             return fn(self, *args, **kwargs)
 
@@ -260,7 +260,7 @@ def _make_synonym_function(compat_name: str, fn: C) -> C:
         @wraps(fn)
         def _inner(*args, **kwargs):
             # warnings.warn(
-            #     f"Deprecated - use {fn.__name__}", DeprecationWarning, stacklevel=3
+            #     f"Deprecated - use {fn.__name__}", DeprecationWarning, stacklevel=2
             # )
             return fn(*args, **kwargs)
 

--- a/pyparsing/util.py
+++ b/pyparsing/util.py
@@ -275,10 +275,3 @@ def _make_synonym_function(compat_name: str, fn: C) -> C:
         _inner.__kwdefaults__ = None
     _inner.__qualname__ = fn.__qualname__
     return cast(C, _inner)
-
-
-def replaced_by_pep8(fn: C) -> Callable[[Callable], C]:
-    """
-    Decorator for pre-PEP8 compatibility synonyms, to link them to the new function.
-    """
-    return lambda other: _make_synonym_function(other.__name__, fn)


### PR DESCRIPTION
* When using the `replaced_by_pep8` decorator with a different method signature for simplicity, as the real signature is generated by the decorator, some static checkers might find false positive errors when calling pyparsing code (see issue #501).
* Refactor the calls for the compatibility code to not use the `replaced_by_pep8` decorator but calling directly the `_make_synonym_function` function to generate the synonym methods/functions.
* This way the signature of the method/function is automatically copied and the static checkers will not report false positives.