### PR TITLE
infix_notation: typo checking type of lpar 

### DIFF
--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -777,7 +777,7 @@ def infix_notation(
         rpar = Suppress(rpar)
 
     # if lpar and rpar are not suppressed, wrap in group
-    if not (isinstance(rpar, Suppress) and isinstance(rpar, Suppress)):
+    if not (isinstance(lpar, Suppress) and isinstance(rpar, Suppress)):
         lastExpr = base_expr | Group(lpar + ret + rpar)
     else:
         lastExpr = base_expr | (lpar + ret + rpar)


### PR DESCRIPTION
It looks like you meant to check both *lpar* and *rpar* here to not be instances of *Suppress*.