### PR TITLE
Minor update to HowToUsePyparsing.rst

### DIFF
--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -836,7 +836,7 @@ Other classes
 
     - elements can be deleted using ``del``
 
-    - the ``-1``th element can be extracted and removed in a single operation
+    - the last element can be extracted and removed in a single operation
       using ``pop()``, or any element can be extracted and removed
       using ``pop(n)``
 


### PR DESCRIPTION
**Fix minor render issue in `HowToUsePyparsing.rst`**

**Before:**

> the `-1``th element can be extracted and removed in a single operation using ``pop()`, or any element can be extracted and removed using `pop(n)`

![image](https://github.com/pyparsing/pyparsing/assets/19711799/f65a4dc7-f22e-461e-bc11-159110bd867d)

**After:**
> the last element can be extracted and removed in a single operation using `pop()`, or any element can be extracted and removed  using `pop(n)`
