### PR TITLE
Avoid assigning an empty error message to delegated parse exception

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -4510,7 +4510,8 @@ class ParseElementEnhance(ParserElement):
             return self.expr._parse(instring, loc, doActions, callPreParse=False)
         except ParseBaseException as pbe:
             if not isinstance(self, Forward) or self.customName is not None:
-                pbe.msg = self.errmsg
+                if self.errmsg:
+                    pbe.msg = self.errmsg
             raise
 
     def leave_whitespace(self, recursive: bool = True) -> ParserElement:


### PR DESCRIPTION
Fixes #527.