### PR TITLE
Accept floating-point NaN and Inf as fnumber

### DIFF
--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -1367,6 +1367,8 @@ Common string and token constants
 
 - ``common.fnumber`` - any numeric expression; parsed tokens are converted to float
 
+- ``common.ieee_float`` - any floating-point literal (int, real number, infinity, or NaN), returned as float
+
 - ``common.identifier`` - a programming identifier (follows Python's syntax convention of leading alpha or "_",
   followed by 0 or more alpha, num, or "_")
 

--- a/pyparsing/common.py
+++ b/pyparsing/common.py
@@ -216,6 +216,13 @@ class pyparsing_common:
     )
     """any int or real number, returned as float"""
 
+    ieee_float = (
+        Regex(r"(?i)[+-]?((\d+\.?\d*(e[+-]?\d+)?)|nan|inf(inity)?)")
+        .set_name("ieee_float")
+        .set_parse_action(convert_to_float)
+    )
+    """any floating-point literal (int, real number, infinity, or NaN), returned as float"""
+
     identifier = Word(identchars, identbodychars).set_name("identifier")
     """typical code identifier (leading alpha or '_', followed by 0 or more alphas, nums, or '_')"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6599,6 +6599,23 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             )[0]
             self.assertTrue(success, "error in parsing valid numerics")
 
+        with self.subTest("ppc.ieee_float success run_tests"):
+            success = ppc.ieee_float.runTests(
+                """
+                100
+                3.14159
+                6.02e23
+                1E-12
+                0
+                -0
+                NaN
+                -nan
+                inf
+                -Infinity
+                """
+            )[0]
+            self.assertTrue(success, "error in parsing valid floating-point literals")
+
         with self.subTest("ppc.iso8601_date success run_tests"):
             success, results = ppc.iso8601_date.runTests(
                 """


### PR DESCRIPTION
I was working on parsing numerical data and found that none of pyparsing's numerical expressions support the non-finite floating point values (NaN, +Inf, and -Inf).

Just based on the implementation, `ppc.fnumber` looks like a reasonable place to add support for this, since it's independent of the other numerical expressions and has the float conversion baked in. (Indeed, I initially thought it would accept these values due to the "float" part.) Essentially, this PR makes `fnumber` match anything that Python's `float` can itself parse. [cPython's parsing](https://github.com/python/cpython/blob/main/Python/pystrtod.c#L28) is fully case-insensitive and accepts (optionally signed) "NaN", "Inf", and "Infinity".

One note of caution would be if users somehow rely on `fnumber`'s failure to parse such constants as a way to deal with NaNs or infinities in their programs.