### PR TITLE
Refactor: remove one isinstance comparison from the runtime code path.

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1506,15 +1506,10 @@ class ParserElement(ABC):
         """
         if other is Ellipsis:
             other = (0, None)
-        elif isinstance(other, tuple) and other[:1] == (Ellipsis,):
-            other = ((0,) + other[1:] + (None,))[:2]
-
-        if not isinstance(other, (int, tuple)):
-            return NotImplemented
 
         if isinstance(other, int):
             minElements, optElements = other, 0
-        else:
+        elif isinstance(other, tuple):
             other = tuple(o if o is not Ellipsis else None for o in other)
             other = (other + (None, None))[:2]
             if other[0] is None:
@@ -1531,6 +1526,8 @@ class ParserElement(ABC):
                 optElements -= minElements
             else:
                 return NotImplemented
+        else:
+            return NotImplemented
 
         if minElements < 0:
             raise ValueError("cannot multiply ParserElement by negative value")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3876,10 +3876,15 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
     def testMulWithEllipsis(self):
         """multiply an expression with Ellipsis as ``expr * ...`` to match ZeroOrMore"""
 
-        expr = pp.Literal("A")("Achar") * ...
-        res = expr.parseString("A", parseAll=True)
-        self.assertEqual(["A"], res.asList(), "expected expr * ... to match ZeroOrMore")
-        print(res.dump())
+        for factor in (..., (...,), (..., 10,)):
+            expr = pp.Literal("A")("Achar") * factor
+            res = expr.parseString("A", parseAll=True)
+            self.assertEqual(
+                ["A"],
+                res.asList(),
+                f"expected expr * {str(factor).replace('Ellipsis', '...')} to match ZeroOrMore",
+            )
+            print(res.dump())
 
     def testUpcaseDowncaseUnicode(self):
         import sys


### PR DESCRIPTION
This is a possible refactor resulting from [inspecting the differences between `v3.1.1` and `v3.1.2`](https://github.com/pyparsing/pyparsing/compare/3.1.1...3.1.2) - I believe that it should remove one conditional/comparison during at typical runtime evaluation without affecting the correctness of the code; and indenting of the source is not affected.

Arguably it does hide the validation-checks a little, by moving one of the `NotImplemented` return paths lower down the method body.

In particular, the `isinstance(other, tuple) and other[:1] == (Ellipsis,)` check and variable reassignments are, I believe, already handled by the code here:

https://github.com/pyparsing/pyparsing/blob/7d4bda2743ebc04f68d2594bc4fffc70cd65848f/pyparsing/core.py#L1518

(which should only be reachable [when `other` is indeed a `tuple`](https://github.com/pyparsing/pyparsing/blob/7d4bda2743ebc04f68d2594bc4fffc70cd65848f/pyparsing/core.py#L1512-L1517))