### PR TITLE
Refactor: attempt to simplify the multiply operator.

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1510,6 +1510,8 @@ class ParserElement(ABC):
             minElements, maxElements = (other + (None, None))[:2]
         elif other is Ellipsis:
             minElements, maxElements = other, None
+        else:
+            return NotImplemented
 
         if minElements in (Ellipsis, None):
             minElements = 0

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1508,28 +1508,25 @@ class ParserElement(ABC):
             minElements, maxElements = other, other
         elif isinstance(other, tuple):
             minElements, maxElements = (other + (None, None))[:2]
+            minElements = 0 if minElements in (None, Ellipsis) else minElements
+            maxElements = None if maxElements in (None, Ellipsis) else maxElements
         elif other is Ellipsis:
-            minElements, maxElements = other, None
+            minElements, maxElements = 0, None
         else:
             return NotImplemented
 
-        if minElements in (Ellipsis, None):
-            minElements = 0
-        elif type(minElements) is not int:
-            return NotImplemented
-        elif minElements < 0:
+        if minElements < 0:
             raise ValueError("cannot multiply ParserElement by negative value")
 
-        if maxElements in (Ellipsis, None):
+        if maxElements is None:
             if minElements == 0:
                 return ZeroOrMore(self)
             elif minElements == 1:
                 return OneOrMore(self)
             else:
                 return (self * minElements) + ZeroOrMore(self)
-        elif type(maxElements) is not int:
-            return NotImplemented
-        elif maxElements < minElements:
+
+        if maxElements < minElements:
             raise ValueError(
                 "second tuple value must be greater or equal to first tuple value"
             )

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1515,7 +1515,7 @@ class ParserElement(ABC):
 
         if minElements in (Ellipsis, None):
             minElements = 0
-        elif type(minElements) != int:
+        elif type(minElements) is not int:
             return NotImplemented
         elif minElements < 0:
             raise ValueError("cannot multiply ParserElement by negative value")
@@ -1527,7 +1527,7 @@ class ParserElement(ABC):
                 return OneOrMore(self)
             else:
                 return (self * minElements) + ZeroOrMore(self)
-        elif type(maxElements) != int:
+        elif type(maxElements) is not int:
             return NotImplemented
         elif maxElements < minElements:
             raise ValueError(

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1534,7 +1534,7 @@ class ParserElement(ABC):
 
         if minElements == maxElements:
             if minElements == 0:
-                return And([])
+                return Empty()
             elif minElements == 1:
                 return self
             else:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1530,7 +1530,9 @@ class ParserElement(ABC):
         elif type(maxElements) != int:
             return NotImplemented
         elif maxElements < minElements:
-            raise ValueError("second tuple value must be greater or equal to first tuple value")
+            raise ValueError(
+                "second tuple value must be greater or equal to first tuple value"
+            )
 
         if minElements == maxElements:
             if minElements == 0:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1513,6 +1513,8 @@ class ParserElement(ABC):
 
         if minElements in (Ellipsis, None):
             minElements = 0
+        elif type(minElements) != int:
+            return NotImplemented
         elif minElements < 0:
             raise ValueError("cannot multiply ParserElement by negative value")
 
@@ -1523,11 +1525,10 @@ class ParserElement(ABC):
                 return OneOrMore(self)
             else:
                 return self * minElements + ZeroOrMore(self)
+        elif type(maxElements) != int:
+            return NotImplemented
         elif maxElements < minElements:
             raise ValueError("second tuple value must be greater or equal to first tuple value")
-
-        if not type(minElements) == type(maxElements) == int:
-            return NotImplemented
 
         if minElements == maxElements:
             if minElements == 0:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1526,7 +1526,7 @@ class ParserElement(ABC):
             elif minElements == 1:
                 return OneOrMore(self)
             else:
-                return self * minElements + ZeroOrMore(self)
+                return (self * minElements) + ZeroOrMore(self)
         elif type(maxElements) != int:
             return NotImplemented
         elif maxElements < minElements:
@@ -1546,7 +1546,7 @@ class ParserElement(ABC):
             else:
                 return Opt(self)
 
-        return self * minElements + makeOptionalList(maxElements - minElements)
+        return (self * minElements) + makeOptionalList(maxElements - minElements)
 
     def __rmul__(self, other) -> "ParserElement":
         return self.__mul__(other)

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1546,7 +1546,7 @@ class ParserElement(ABC):
             else:
                 return Opt(self)
 
-        return And([self] * minElements) + makeOptionalList(maxElements - minElements)
+        return self * minElements + makeOptionalList(maxElements - minElements)
 
     def __rmul__(self, other) -> "ParserElement":
         return self.__mul__(other)

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1540,7 +1540,13 @@ class ParserElement(ABC):
             else:
                 return And([self] * minElements)
 
-        return And([self] * minElements) + (Opt(self) * (maxElements - minElements))
+        def makeOptionalList(n):
+            if n > 1:
+                return Opt(self + makeOptionalList(n - 1))
+            else:
+                return Opt(self)
+
+        return And([self] * minElements) + makeOptionalList(maxElements - minElements)
 
     def __rmul__(self, other) -> "ParserElement":
         return self.__mul__(other)

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1504,6 +1504,9 @@ class ParserElement(ABC):
         occurrences.  If this behavior is desired, then write
         ``expr*(None, n) + ~expr``
         """
+        minElements: int
+        maxElements: typing.Optional[int]
+
         if isinstance(other, int):
             minElements, maxElements = other, other
         elif isinstance(other, tuple):

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1510,8 +1510,6 @@ class ParserElement(ABC):
             minElements, maxElements = (other + (None, None))[:2]
         elif other is Ellipsis:
             minElements, maxElements = other, None
-        else:
-            return NotImplemented
 
         if minElements in (Ellipsis, None):
             minElements = 0
@@ -1527,6 +1525,9 @@ class ParserElement(ABC):
                 return self * minElements + ZeroOrMore(self)
         elif maxElements < minElements:
             raise ValueError("second tuple value must be greater or equal to first tuple value")
+
+        if not type(minElements) == type(maxElements) == int:
+            return NotImplemented
 
         if minElements == maxElements:
             if minElements == 0:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3873,10 +3873,15 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
     def testMulWithEllipsis(self):
         """multiply an expression with Ellipsis as ``expr * ...`` to match ZeroOrMore"""
 
-        expr = pp.Literal("A")("Achar") * ...
-        res = expr.parseString("A", parseAll=True)
-        self.assertEqual(["A"], res.asList(), "expected expr * ... to match ZeroOrMore")
-        print(res.dump())
+        for factor in (..., (...,), (..., 10,)):
+            expr = pp.Literal("A")("Achar") * factor
+            res = expr.parseString("A", parseAll=True)
+            self.assertEqual(
+                ["A"],
+                res.asList(),
+                f"expected expr * {str(factor).replace('Ellipsis', '...')} to match ZeroOrMore",
+            )
+            print(res.dump())
 
     def testUpcaseDowncaseUnicode(self):
         import sys


### PR DESCRIPTION
* Reduce the amount of special-case logic required to handle the `Ellipsis` operator (somewhat equivalent/similar to `None` values -- translating to: unbound).
* Extract some parallels between the handling of "zero, one, or more" in the cases of unbounded-maximum or singleton repetitions.

cc @ptmcg 