### PR TITLE
Fix typo in examples

### DIFF
--- a/examples/eval_arith.py
+++ b/examples/eval_arith.py
@@ -59,7 +59,7 @@ def operatorOperands(tokenlist):
 
 
 class EvalPowerOp:
-    "Class to evaluate multiplication and division expressions"
+    "Class to evaluate power expressions"
 
     def __init__(self, tokens):
         self.value = tokens[0]


### PR DESCRIPTION
Found a small confusing inaccuracy in the examples