### PR TITLE
[3.1.3] Revert 3bb8076 for Python 3.6

### DIFF
--- a/pyparsing/unicode.py
+++ b/pyparsing/unicode.py
@@ -54,7 +54,7 @@ class unicode_set:
 
     @_lazyclassproperty
     def _chars_for_ranges(cls) -> List[str]:
-        ret: List[int] = []
+        ret = []
         for cc in cls.__mro__:
             if cc is unicode_set:
                 break

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9418,10 +9418,8 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         tests = [
             ("ABCDEMNXYZ", "[A-EMNX-Z]+"),
             (pp.printables, "[!-~]+"),
-            (pp.alphas, "[A-Za-z]+"),
             (pp.alphanums, "[0-9A-Za-z]+"),
             (pp.pyparsing_unicode.Latin1.printables, "[!-~¡-ÿ]+"),
-            (pp.pyparsing_unicode.Latin1.alphas, "[A-Za-zªµºÀ-ÖØ-öø-ÿ]+"),
             (pp.pyparsing_unicode.Latin1.alphanums, "[0-9A-Za-zª²³µ¹ºÀ-ÖØ-öø-ÿ]+"),
             (pp.alphas8bit, "[À-ÖØ-öø-ÿ]+"),
         ]


### PR DESCRIPTION
Revert "Some PEP8 naming and type annotations; added some test cases for string->regex in Word"

This reverts commit 3bb8076ffae804f398f14af0d887e131c9ffb312.

Fixes https://github.com/pyparsing/pyparsing/issues/564