### PR TITLE
Add Python 3.6 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         toxenv: [py]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
+          - python-version: "3.6"
+            os: ubuntu-20.04
           - python-version: "3.11"
             os: macos-latest
           - python-version: "3.11"

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -53,6 +53,11 @@ from .unicode import pyparsing_unicode
 _MAX_INT = sys.maxsize
 str_type: Tuple[type, ...] = (str, bytes)
 
+if sys.version_info >= (3, 7):
+    _RePattern = re.Pattern
+else:
+    _RePattern = typing.Pattern
+
 #
 # Copyright (c) 2003-2022  Paul T. McGuire
 #
@@ -3057,7 +3062,7 @@ class Regex(Token):
             self.parseImpl = self.parseImplAsMatch  # type: ignore [assignment]
 
     @cached_property
-    def re(self) -> re.Pattern:
+    def re(self) -> _RePattern:
         if self._re:
             return self._re
 


### PR DESCRIPTION
The second commit should fix the problem, **but** right now it won't work since pyparsing 3.1.3 is still out there. Tox fails before even running the code from this repo: https://github.com/felixfontein/pyparsing/actions/runs/10546308170/job/29217617943?pr=1

(I've a mirror PR of this in my fork where I don't have to wait for CI to be approved: https://github.com/felixfontein/pyparsing/pull/1)