### PR TITLE
fix: Python 3.8 doesn't support type hinting with subscripted generics like list[str].

### DIFF
--- a/pyparsing/util.py
+++ b/pyparsing/util.py
@@ -1,4 +1,5 @@
 # util.py
+from typing import List
 import inspect
 import warnings
 import types
@@ -14,8 +15,8 @@ C = TypeVar("C", bound=Callable)
 class __config_flags:
     """Internal class for defining compatibility and debugging flags"""
 
-    _all_names: list[str] = []
-    _fixed_names: list[str] = []
+    _all_names: List[str] = []
+    _fixed_names: List[str] = []
     _type_desc = "configuration"
 
     @classmethod


### PR DESCRIPTION
## Fix List[str] type hint compatibility for Python 3.8
### Problem
The current pre-release version of pyparsing (3.2.0b1) uses the List[str] syntax for type hinting, which is not compatible with Python 3.8. This causes a TypeError: 'type' object is not subscriptable when users try to import pyparsing in Python 3.8 environments.
Specifically, in util.py, the following line is causing issues:
pythonCopy_all_names: list[str] = []
This syntax for generic type hints was introduced in Python 3.9, making it incompatible with Python 3.8 and earlier versions.
### Solution
This pull request modifies the type hints to use the typing.List notation, which is compatible with Python 3.8:
```py
from typing import List # import List type hint

_all_names: List[str] = [] # use List instead of list
```
This change maintains type hinting functionality while ensuring compatibility with Python 3.8.
Impact

Resolves the TypeError when importing pyparsing in Python 3.8 environments.
Maintains type hinting benefits for static type checkers and IDEs.
Ensures backward compatibility with Python 3.8 without losing type information.

### Additional Notes

This change does not affect the runtime behavior of pyparsing.
Users of Python 3.9+ can continue to use the library as before.
Consider adding a note in the documentation about the minimum supported Python version for different pyparsing releases.

Please review and let me know if any further modifications are needed.