### PR TITLE
Add found string as property

### DIFF
--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -5,15 +5,16 @@ import copy
 import re
 import sys
 import typing
+from functools import cached_property
 
+from .unicode import pyparsing_unicode as ppu
 from .util import (
+    _collapse_string_to_ranges,
     col,
     line,
     lineno,
-    _collapse_string_to_ranges,
     replaced_by_pep8,
 )
-from .unicode import pyparsing_unicode as ppu
 
 
 class _ExceptionWordUnicodeSet(
@@ -134,35 +135,35 @@ class ParseBaseException(Exception):
         """
         return cls(pe.pstr, pe.loc, pe.msg, pe.parser_element)
 
-    @property
+    @cached_property
     def line(self) -> str:
         """
         Return the line of text where the exception occurred.
         """
         return line(self.loc, self.pstr)
 
-    @property
+    @cached_property
     def lineno(self) -> int:
         """
         Return the 1-based line number of text where the exception occurred.
         """
         return lineno(self.loc, self.pstr)
 
-    @property
+    @cached_property
     def col(self) -> int:
         """
         Return the 1-based column on the line of text where the exception occurred.
         """
         return col(self.loc, self.pstr)
 
-    @property
+    @cached_property
     def column(self) -> int:
         """
         Return the 1-based column on the line of text where the exception occurred.
         """
         return col(self.loc, self.pstr)
 
-    @property
+    @cached_property
     def found(self) -> str:
         if not self.pstr:
             return ""

--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -162,6 +162,23 @@ class ParseBaseException(Exception):
         """
         return col(self.loc, self.pstr)
 
+    @property
+    def found(self) -> str:
+        if not self.pstr:
+            return ""
+
+        if self.loc >= len(self.pstr):
+            return "end of text"
+
+        # pull out next word at error location
+        found_match = _exception_word_extractor.match(self.pstr, self.loc)
+        if found_match is not None:
+            found = found_match.group(0)
+        else:
+            found = self.pstr[self.loc : self.loc + 1]
+
+        return repr(found).replace(r"\\", "\\")
+
     # pre-PEP8 compatibility
     @property
     def parserElement(self):
@@ -175,19 +192,7 @@ class ParseBaseException(Exception):
         return copy.copy(self)
 
     def __str__(self) -> str:
-        if self.pstr:
-            if self.loc >= len(self.pstr):
-                foundstr = ", found end of text"
-            else:
-                # pull out next word at error location
-                found_match = _exception_word_extractor.match(self.pstr, self.loc)
-                if found_match is not None:
-                    found = found_match.group(0)
-                else:
-                    found = self.pstr[self.loc : self.loc + 1]
-                foundstr = (", found %r" % found).replace(r"\\", "\\")
-        else:
-            foundstr = ""
+        foundstr = f", found {self.found}" if self.found else ""
         return f"{self.msg}{foundstr}  (at char {self.loc}), (line:{self.lineno}, col:{self.column})"
 
     def __repr__(self):

--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -192,9 +192,12 @@ class ParseBaseException(Exception):
     def copy(self):
         return copy.copy(self)
 
+    def formatted_message(self):
+        found_phrase = f", found {self.found}" if self.found else ""
+        return f"{self.msg}{found_phrase}  (at char {self.loc}), (line:{self.lineno}, col:{self.column})"
+
     def __str__(self) -> str:
-        foundstr = f", found {self.found}" if self.found else ""
-        return f"{self.msg}{foundstr}  (at char {self.loc}), (line:{self.lineno}, col:{self.column})"
+        return self.formatted_message()
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
A bit of a silly change, feel free to close if you don't accept these.

I have moved the logic of the "found" string out of the `__str__` magic method. This allows the user to generate prettier messages from the exception. I also think it's a bit cleaner to avoid parsing logic in `__str__`

## Example
From the following exception

```Python
In [2]: Keyword("KEY1").parse_string("KEY2", parseAll=True)
---------------------------------------------------------------------------
ParseException                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 Keyword("KEY1").parse_string("KEY2", parseAll=True)

File ~/Documents/pyparsing/pyparsing/core.py:1197, in ParserElement.parse_string(self, instring, parse_all, parseAll)
   1194         raise
   1195     else:
   1196         # catch and re-raise exception from here, clearing out pyparsing internal stack trace
-> 1197         raise exc.with_traceback(None)
   1198 else:
   1199     return tokens

ParseException: Expected Keyword 'KEY1', found 'KEY2'  (at char 0), (line:1, col:1)
```
I would like to generate a message like this

```
1:1 Expected Keyword 'KEY1', found 'KEY2' 
```

With the existing implementation the user would have to call  `__str__` and then remove the character, line and column information. 