### PR TITLE
Improve performance of cpp_style_comment

### DIFF
--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -1023,9 +1023,7 @@ rest_of_line = Regex(r".*").leave_whitespace().set_name("rest of line")
 dbl_slash_comment = Regex(r"//(?:\\\n|[^\n])*").set_name("// comment")
 "Comment of the form ``// ... (to end of line)``"
 
-cpp_style_comment = Combine(
-    Regex(r"/\*(?:[^*]|\*(?!/))*") + "*/" | dbl_slash_comment
-).set_name("C++ style comment")
+cpp_style_comment = Regex(r"(?:/\*(?:[^*]|\*(?!/))*\*/)|(?://(?:\\\n|[^\n])*)").set_name("C++ style comment")
 "Comment of either form :class:`c_style_comment` or :class:`dbl_slash_comment`"
 
 java_style_comment = cpp_style_comment


### PR DESCRIPTION
Improve performance of the `cpp_style_comment` helper by rewriting it as a single `Regex`.

This change leads to very significant performance improvements when parsing grammars that use `.ignore(cpp_style_comment)`.