### PR TITLE
Use non-capturing groups in common.fnumber and common.ieee_float

### DIFF
--- a/pyparsing/common.py
+++ b/pyparsing/common.py
@@ -210,14 +210,14 @@ class pyparsing_common:
     """any numeric expression, returns the corresponding Python type"""
 
     fnumber = (
-        Regex(r"[+-]?\d+\.?\d*([eE][+-]?\d+)?")
+        Regex(r"[+-]?\d+\.?\d*(?:[eE][+-]?\d+)?")
         .set_name("fnumber")
         .set_parse_action(convert_to_float)
     )
     """any int or real number, returned as float"""
 
     ieee_float = (
-        Regex(r"(?i)[+-]?((\d+\.?\d*(e[+-]?\d+)?)|nan|inf(inity)?)")
+        Regex(r"(?i:[+-]?(?:(?:\d+\.?\d*(?:e[+-]?\d+)?)|nan|inf(?:inity)?))")
         .set_name("ieee_float")
         .set_parse_action(convert_to_float)
     )


### PR DESCRIPTION
Non-capturing groups are faster to parse and IMO show the intent better. Also, the `(?i:...)` inline flag in this format does not need to be at the beginning of the regular expression, allowing for the pattern to be easily reused as part of other custom `Regex`es (e.g. by extracting it as `pyparsing.common.ieee_float.re.pattern`—not sure you want to encourage this, but TBF I'm doing something like this in my own project that uses this library).