### PR TITLE
Docs: Correct encoding damage in What's New 3.2

### DIFF
--- a/docs/whats_new_in_3_2.rst
+++ b/docs/whats_new_in_3_2.rst
@@ -117,7 +117,7 @@ New / Enhanced Examples
   Robert Nystrom's "Crafting Interpreters" (http://craftinginterpreters.com/).
 
 - Added ``complex_chemical_formulas.py`` example, to add parsing capability for
-  formulas such as "3(Câ‚†Hâ‚…OH)â‚‚".
+  formulas such as "Ba(BrO₃)₂·H₂O".
 
 - Updated ``tag_emitter.py`` to use new ``Tag`` class, introduced in pyparsing
   3.1.3.


### PR DESCRIPTION
The mention of `complex_chemical_formulas.py` being included "to add parsing capability for formulas such as..." was followed by a string of line-noise that looked nothing like a chemical formula, and was clearly not UTF-8 text or anything close to it. Replace with real UTF-8 from the actual source file.