### PR TITLE
Fix inline code missing space for termination

### DIFF
--- a/docs/whats_new_in_3_2.rst
+++ b/docs/whats_new_in_3_2.rst
@@ -96,7 +96,7 @@ Additional API changes
   return the parsed values in a flattened list.
 
 - Added ``indent`` and ``base_1`` arguments to ``pyparsing.testing.with_line_numbers``. When
-  using ``with_line_numbers`` inside a parse action, set ``base_1``=False, since the
+  using ``with_line_numbers`` inside a parse action, set ``base_1`` =False, since the
   reported ``loc`` value is 0-based. ``indent`` can be a leading string (typically of
   spaces or tabs) to indent the numbered string passed to ``with_line_numbers``.
 


### PR DESCRIPTION
Just a very small thing I noticed while reading the rendered docs at RTD. The space makes sure the inline code block is terminated after `base_1` and therefore avoids rendering the entire sentence up to `loc` as a code section.

I wasn't sure which delineation was intended, so I kept the code as-is and just added the space. There is an alternative to include the `=False` in the code section as well:

```diff
- using ``with_line_numbers`` inside a parse action, set ``base_1``=False, since the
+ using ``with_line_numbers`` inside a parse action, set ``base_1=False``, since the
```

If the alternative is desired, I can quickly push that up instead. :+1:

Edit: The odd formatting can currently be seen [here](https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_2.html#additional-api-changes).