### PR TITLE
QuotedString: Add caution about param interactions

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3263,6 +3263,9 @@ class QuotedString(Token):
       (``'\t'``, ``'\n'``, etc.) to actual whitespace
       (default= ``True``)
 
+    .. caution:: ``convert_whitespace_escapes`` has no effect if
+       ``unquote_results`` is ``False``.
+
     Example::
 
         qs = QuotedString('"')


### PR DESCRIPTION
Looking at adjusting the pydot GraphViz parser's handling of quoted strings, I was rather surprised to discover an unexpected interaction in the `QuotedString` parameters:

As implemented in `QuotedString`, `convert_whitespace_escapes` **has no effect** unless `unquote_results` is set to `True`. 

This PR adds a Caution admonition to the API documentation, advising users of this restriction.