### PR TITLE
Docs: A raft of cleanup & style changes

### DIFF
--- a/docs/HowToUsePyparsing.rst
+++ b/docs/HowToUsePyparsing.rst
@@ -19,8 +19,6 @@ Using the pyparsing module
     expressions, processing custom application language commands, or
     extracting data from formatted reports.
 
-.. sectnum::    :depth: 4
-
 .. contents::   :depth: 4
 
 Note: While this content is still valid, there are more detailed

--- a/docs/_static/pyparsing.css
+++ b/docs/_static/pyparsing.css
@@ -1,0 +1,44 @@
+/* Deprecated get a red border spanning the entire length of the doc
+ * (class, function, etc.), and the message itself has a faint red
+ * background shading, but no border. */
+dl.py:where(.class,.exception,.method,.function):has(> dd > div.deprecated)
+{
+    margin-inline-start: -0.6rem;
+    border-inline-start: 0.4rem solid #f00;
+    padding: 0 0.6rem 0 0.2rem;
+}
+
+span.deprecated {
+  background-color: #fee;
+  font-weight: bold;
+  text-decoration: #f00 underline;
+  padding: 0 0.5rem;
+}
+
+/* Added and changed get a blue or orange (respectively) border next to
+ * the message only, plus a light background shade of the same color
+ * (again, only on the message, not the rest of the doc). */
+div.versionadded, div.versionchanged
+{
+    border-inline-start: 0.4rem solid transparent;
+}
+
+div.versionchanged p,
+div.versionadded p,
+span.versionmodified {
+  line-height: initial;
+  padding-bottom: 0.2rem;
+  padding-top: 0.2rem;
+}
+span.versionmodified {
+  padding-inline-start: 0.5rem;
+  padding-inline-end: 0.2rem;
+  margin-inline-end: 0.5rem;
+  line-height: 130%;
+}
+
+div.versionadded { border-color: #2d67f3; }
+div.versionadded span.added { background-color: #d1e5ff; }
+
+div.versionchanged { border-color: #ff9800; }
+div.versionchanged span.changed { background-color: #ffddac; }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,4 +181,18 @@ epub_copyright = copyright
 epub_exclude_files = ["search.html"]
 
 
+# -- Domain configuration ----------------------------------------------------
+
+python_use_unqualified_type_names = True
+python_display_short_literal_types = True
+python_maximum_signature_line_length = 100
+add_module_names = False
+toc_object_entries_show_parents = 'hide'
+
 # -- Extension configuration -------------------------------------------------
+autodoc_class_signature = 'mixed'
+autodoc_mock_imports = ['railroad']
+autodoc_preserve_defaults = True
+autodoc_default_options = {
+    'class-doc-from': 'both',
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,10 @@ html_theme = "classic"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+html_css_files = {
+    "pyparsing.css": "*",
+}
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,15 +7,16 @@ Welcome to PyParsing's documentation!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Release v\ |version|
 
+.. rubric:: Contents
+
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
    HowToUsePyparsing
    whats_new_in_3_2
    whats_new_in_3_1
    whats_new_in_3_0_0
-   modules
+   pyparsing
    CODE_OF_CONDUCT
 
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-pyparsing
-=========
-
-.. toctree::
-   :maxdepth: 4
-
-   pyparsing

--- a/docs/pyparsing.rst
+++ b/docs/pyparsing.rst
@@ -1,7 +1,18 @@
-pyparsing module
-================
+pyparsing API
+=============
 
 .. automodule:: pyparsing
     :members:
-    :special-members:
+    :undoc-members:
+    :special-members: __add__,__sub__,__div__,__mul__,__and__,__or__,__xor__,__call__,__weakref__,__str__
+    :exclude-members: __init__,__repl__,parseImpl,parseImpl_regex,parseImplAsGroupList,parseImplAsMatch,postParse,preParse
     :show-inheritance:
+
+.. 'hidden' prevents the toctree from appearing at the bottom of the page
+
+.. toctree::
+   :maxdepth: 4
+   :hidden:
+
+   self
+

--- a/docs/whats_new_in_3_0_0.rst
+++ b/docs/whats_new_in_3_0_0.rst
@@ -10,8 +10,6 @@ What's New in Pyparsing 3.0.0
     in the 3.0.0 release of pyparsing.
     (Updated to reflect changes up to 3.0.10)
 
-.. sectnum::    :depth: 4
-
 .. contents::   :depth: 4
 
 

--- a/docs/whats_new_in_3_1.rst
+++ b/docs/whats_new_in_3_1.rst
@@ -9,8 +9,6 @@ What's New in Pyparsing 3.1.0
 :abstract: This document summarizes the changes made
     in the 3.1.x releases of pyparsing.
 
-.. sectnum::    :depth: 4
-
 .. contents::   :depth: 4
 
 

--- a/docs/whats_new_in_3_2.rst
+++ b/docs/whats_new_in_3_2.rst
@@ -9,8 +9,6 @@ What's New in Pyparsing 3.2.0
 :abstract: This document summarizes the changes made
     in the 3.2.x releases of pyparsing.
 
-.. sectnum::    :depth: 4
-
 .. contents::   :depth: 4
 
 

--- a/docs/whats_new_in_x_x_template.rst.txt
+++ b/docs/whats_new_in_x_x_template.rst.txt
@@ -9,8 +9,6 @@ What's New in Pyparsing 3.x.0
 :abstract: This document summarizes the changes made
     in the 3.x.x releases of pyparsing.
 
-.. sectnum::    :depth: 4
-
 .. contents::   :depth: 4
 
 

--- a/pyparsing/__init__.py
+++ b/pyparsing/__init__.py
@@ -23,15 +23,15 @@
 #
 
 __doc__ = """
-pyparsing module - Classes and methods to define and execute parsing grammars
-=============================================================================
+pyparsing - Classes and methods to define and execute parsing grammars
+======================================================================
 
-The pyparsing module is an alternative approach to creating and
-executing simple grammars, vs. the traditional lex/yacc approach, or the
-use of regular expressions.  With pyparsing, you don't need to learn
-a new syntax for defining grammars or matching expressions - the parsing
-module provides a library of classes that you use to construct the
-grammar directly in Python.
+Pyparsing is an alternative approach to creating and executing simple
+grammars, vs. the traditional lex/yacc approach, or the use of regular
+expressions.  With pyparsing, you don't need to learn a new syntax for
+defining grammars or matching expressions - the parsing module provides
+a library of classes that you use to construct the grammar directly in
+Python.
 
 Here is a program to parse "Hello, World!" (or any greeting of the form
 ``"<salutation>, <addressee>!"``), built up using :class:`Word`,
@@ -69,8 +69,8 @@ vexing when writing text parsers:
   - embedded comments
 
 
-Getting Started -
------------------
+Getting Started
+---------------
 Visit the classes :class:`ParserElement` and :class:`ParseResults` to
 see the base classes that most other pyparsing
 classes inherit from. Use the docstrings for examples of how to:

--- a/pyparsing/common.py
+++ b/pyparsing/common.py
@@ -414,7 +414,12 @@ class pyparsing_common:
         r"(#(?P<fragment>\S*))?" +
         r")"
     ).set_name("url")
-    """URL (http/https/ftp scheme)"""
+    """
+    URL (http/https/ftp scheme)
+    
+    .. versionchanged:: 3.1.0
+       ``url`` named group added
+    """
     # fmt: on
 
     # pre-PEP8 compatibility names

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -445,6 +445,7 @@ class ParserElement(ABC):
 
             LPAR, RPAR, LBRACE, RBRACE, SEMI = Suppress.using_each("(){};")
 
+        .. versionadded:: 3.1.0
         """
         yield from (cls(obj, **class_kwargs) for obj in seq)
 
@@ -1606,6 +1607,9 @@ class ParserElement(ABC):
     def __or__(self, other) -> ParserElement:
         """
         Implementation of ``|`` operator - returns :class:`MatchFirst`
+
+        .. versionchanged:: 3.1.0
+           Support ``expr | ""`` as a synonym for ``Optional(expr)``.
         """
         if other is Ellipsis:
             return _PendingSkip(self, must_skip=True)
@@ -1704,6 +1708,8 @@ class ParserElement(ABC):
         - ``expr[...: end_expr]`` and ``expr[0, ...: end_expr]`` are equivalent to ``ZeroOrMore(expr, stop_on=end_expr)``
         - ``expr[1, ...: end_expr]`` is equivalent to ``OneOrMore(expr, stop_on=end_expr)``
 
+        .. versionchanged:: 3.1.0
+           Support for slice notation.
         """
 
         stop_on_defined = False
@@ -1896,6 +1902,9 @@ class ParserElement(ABC):
         message is shown. Also note the use of :class:`set_name` to assign a human-readable name to the expression,
         which makes debugging and exception messages easier to understand - for instance, the default
         name created for the :class:`Word` expression without calling ``set_name`` is ``"W:(A-Za-z)"``.
+
+        .. versionchanged:: 3.1.0
+           ``recurse`` argument added.
         """
         if recurse:
             for expr in self.visit_all():
@@ -1940,6 +1949,9 @@ class ParserElement(ABC):
 
             integer.set_name("integer")
             integer.parse_string("ABC")  # -> Exception: Expected integer (at char 0), (line:1, col:1)
+        
+        .. versionchanged:: 3.1.0
+           Accept ``None`` as the ``name`` argument.
         """
         self.customName = name  # type: ignore[assignment]
         self.errmsg = f"Expected {str(self)}"
@@ -2305,6 +2317,9 @@ class ParserElement(ABC):
 
         Additional diagram-formatting keyword arguments can also be included;
         see railroad.Diagram class.
+
+        .. versionchanged:: 3.1.0
+           ``embed`` argument added.
         """
 
         try:
@@ -2837,6 +2852,12 @@ class Word(Token):
 
         # any string of non-whitespace characters, except for ','
         csv_value = Word(printables, exclude_chars=",")
+
+    :raises ValueError: If ``min`` and ``max`` are both specified
+                        and the test ``min <= max`` fails.
+
+    .. versionchanged:: 3.1.0
+       Raises :exc:`ValueError` if ``min`` > ``max``.
     """
 
     def __init__(
@@ -3872,6 +3893,8 @@ class Tag(Token):
 
         ['Hello,', 'World', '!']
         - enthusiastic: True
+
+    .. versionadded:: 3.1.0
     """
 
     def __init__(self, tag_name: str, value: Any = True) -> None:
@@ -5266,6 +5289,8 @@ class DelimitedList(ParseElementEnhance):
 
         DelimitedList(Word(alphas)).parse_string("aa,bb,cc") # -> ['aa', 'bb', 'cc']
         DelimitedList(Word(hexnums), delim=':', combine=True).parse_string("AA:BB:CC:DD:EE") # -> ['AA:BB:CC:DD:EE']
+
+    .. versionadded:: 3.1.0
     """
 
     def __init__(
@@ -6069,6 +6094,7 @@ class Suppress(TokenConverter):
         return self
 
 
+# XXX: Example needs to be re-done for updated output
 def trace_parse_action(f: ParseAction) -> ParseAction:
     """Decorator for debugging parse actions.
 
@@ -6093,6 +6119,9 @@ def trace_parse_action(f: ParseAction) -> ParseAction:
         >>entering remove_duplicate_chars(line: 'slkdjs sld sldd sdlf sdljf', 0, (['slkdjs', 'sld', 'sldd', 'sdlf', 'sdljf'], {}))
         <<leaving remove_duplicate_chars (ret: 'dfjkls')
         ['dfjkls']
+
+    .. versionchanged:: 3.1.0
+       Exception type added to output
     """
     f = _trim_arity(f)
 
@@ -6268,6 +6297,8 @@ quoted_string = Combine(
     )
 ).set_name("quoted string using single or double quotes")
 
+# XXX: Is there some way to make this show up in API docs?
+# .. versionadded:: 3.1.0
 python_quoted_string = Combine(
     (Regex(r'"""(?:[^"\\]|""(?!")|"(?!"")|\\.)*', flags=re.MULTILINE) + '"""').set_name(
         "multiline double quoted string"

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -1979,7 +1979,11 @@ class ParserElement(ABC):
 
     def validate(self, validateTrace=None) -> None:
         """
+        .. deprecated:: 3.0.0
+           Do not use to check for left recursion.
+
         Check defined expressions for valid structure, check for infinite recursive definitions.
+
         """
         warnings.warn(
             "ParserElement.validate() is deprecated, and should not be used to check for left recursion",

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -2834,7 +2834,7 @@ class Word(Token):
     - :class:`printables` (any non-whitespace character)
 
     ``alphas``, ``nums``, and ``printables`` are also defined in several
-    Unicode sets - see :class:`pyparsing_unicode``.
+    Unicode sets - see :class:`pyparsing_unicode`.
 
     Example::
 

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3052,6 +3052,11 @@ class Regex(Token):
     (such as the ``regex`` module), you can do so by building your ``Regex`` object with
     a compiled RE that was compiled using ``regex``.
 
+    The parameters ``pattern`` and ``flags`` are passed
+    to the ``re.compile()`` function as-is. See the Python
+    `re module <https://docs.python.org/3/library/re.html>`_ module for an
+    explanation of the acceptable patterns and flags.
+
     Example::
 
         realnum = Regex(r"[+-]?\d+\.\d*")
@@ -3076,11 +3081,6 @@ class Regex(Token):
         asGroupList: bool = False,
         asMatch: bool = False,
     ) -> None:
-        """The parameters ``pattern`` and ``flags`` are passed
-        to the ``re.compile()`` function as-is. See the Python
-        `re module <https://docs.python.org/3/library/re.html>`_ module for an
-        explanation of the acceptable patterns and flags.
-        """
         super().__init__()
         asGroupList = asGroupList or as_group_list
         asMatch = asMatch or as_match
@@ -5246,6 +5246,24 @@ class ZeroOrMore(_MultipleMatch):
 
 
 class DelimitedList(ParseElementEnhance):
+    """Helper to define a delimited list of expressions - the delimiter
+    defaults to ','. By default, the list elements and delimiters can
+    have intervening whitespace, and comments, but this can be
+    overridden by passing ``combine=True`` in the constructor. If
+    ``combine`` is set to ``True``, the matching tokens are
+    returned as a single token string, with the delimiters included;
+    otherwise, the matching tokens are returned as a list of tokens,
+    with the delimiters suppressed.
+
+    If ``allow_trailing_delim`` is set to True, then the list may end with
+    a delimiter.
+
+    Example::
+
+        DelimitedList(Word(alphas)).parse_string("aa,bb,cc") # -> ['aa', 'bb', 'cc']
+        DelimitedList(Word(hexnums), delim=':', combine=True).parse_string("AA:BB:CC:DD:EE") # -> ['AA:BB:CC:DD:EE']
+    """
+
     def __init__(
         self,
         expr: Union[str, ParserElement],
@@ -5256,23 +5274,6 @@ class DelimitedList(ParseElementEnhance):
         *,
         allow_trailing_delim: bool = False,
     ) -> None:
-        """Helper to define a delimited list of expressions - the delimiter
-        defaults to ','. By default, the list elements and delimiters can
-        have intervening whitespace, and comments, but this can be
-        overridden by passing ``combine=True`` in the constructor. If
-        ``combine`` is set to ``True``, the matching tokens are
-        returned as a single token string, with the delimiters included;
-        otherwise, the matching tokens are returned as a list of tokens,
-        with the delimiters suppressed.
-
-        If ``allow_trailing_delim`` is set to True, then the list may end with
-        a delimiter.
-
-        Example::
-
-            DelimitedList(Word(alphas)).parse_string("aa,bb,cc") # -> ['aa', 'bb', 'cc']
-            DelimitedList(Word(hexnums), delim=':', combine=True).parse_string("AA:BB:CC:DD:EE") # -> ['AA:BB:CC:DD:EE']
-        """
         if isinstance(expr, str_type):
             expr = ParserElement._literalStringClass(expr)
         expr = typing.cast(ParserElement, expr)

--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -192,10 +192,20 @@ class ParseBaseException(Exception):
         return copy.copy(self)
 
     def formatted_message(self) -> str:
+        """
+        Output the formatted exception message.
+        Can be overridden to customize the message formatting or contents.
+
+        .. versionadded:: 3.2.0
+        """
         found_phrase = f", found {self.found}" if self.found else ""
         return f"{self.msg}{found_phrase}  (at char {self.loc}), (line:{self.lineno}, col:{self.column})"
 
     def __str__(self) -> str:
+        """
+        .. versionchanged:: 3.2.0
+           Now uses :meth:`formatted_message` to format message.
+        """
         return self.formatted_message()
 
     def __repr__(self):

--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -299,11 +299,12 @@ class ParseSyntaxException(ParseFatalException):
 
 class RecursiveGrammarException(Exception):
     """
+    .. deprecated:: 3.0.0
+       Only used by the deprecated :meth:`ParserElement.validate`.
+
     Exception thrown by :class:`ParserElement.validate` if the
     grammar could be left-recursive; parser may need to enable
     left recursion using :class:`ParserElement.enable_left_recursion<ParserElement.enable_left_recursion>`
-
-    Deprecated: only used by deprecated method ParserElement.validate.
     """
 
     def __init__(self, parseElementList) -> None:

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -385,7 +385,9 @@ def ungroup(expr: ParserElement) -> ParserElement:
 
 def locatedExpr(expr: ParserElement) -> ParserElement:
     """
-    (DEPRECATED - future code should use the :class:`Located` class)
+    .. deprecated:: 3.0.0
+       Use the :class:`Located` class instead.
+
     Helper to decorate a returned token with its starting and ending
     locations in the input string.
 
@@ -914,7 +916,9 @@ def infix_notation(
 
 def indentedBlock(blockStatementExpr, indentStack, indent=True, backup_stacks=[]):
     """
-    (DEPRECATED - use :class:`IndentedBlock` class instead)
+    .. deprecated:: 3.0.0
+       Use the :class:`IndentedBlock` class instead.
+
     Helper method for defining space-delimited indentation blocks,
     such as those used to define block statements in Python source code.
 
@@ -1096,7 +1100,10 @@ def delimited_list(
     *,
     allow_trailing_delim: bool = False,
 ) -> ParserElement:
-    """(DEPRECATED - use :class:`DelimitedList` class)"""
+    """
+    .. deprecated:: 3.1.0
+       Use the :class:`DelimitedList` class instead.
+    """
     return DelimitedList(
         expr, delim, combine, min, max, allow_trailing_delim=allow_trailing_delim
     )

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -587,6 +587,8 @@ class ParseResults:
     def deepcopy(self) -> ParseResults:
         """
         Returns a new deep copy of a :class:`ParseResults` object.
+
+        .. versionadded:: 3.1.0
         """
         ret = self.copy()
         # replace values with copies if they are of known mutable types

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -804,12 +804,17 @@ class ParseResults:
             ret = cls([ret], name=name)
         return ret
 
+    # XXX: These docstrings don't show up in the documentation
+    #      (asList.__doc__ is the same as as_list.__doc__)
     asList = as_list
-    """Deprecated - use :class:`as_list`"""
+    """.. deprecated:: 3.0.0
+          use :class:`as_list`"""
     asDict = as_dict
-    """Deprecated - use :class:`as_dict`"""
+    """.. deprecated:: 3.0.0
+          use :class:`as_dict`"""
     getName = get_name
-    """Deprecated - use :class:`get_name`"""
+    """.. deprecated:: 3.0.0
+          use :class:`get_name`"""
 
 
 MutableMapping.register(ParseResults)

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -522,6 +522,9 @@ class ParseResults:
             # Use as_list() to create an actual list
             result_list = result.as_list()
             print(type(result_list), result_list) # -> <class 'list'> ['sldkj', 'lsdkj', 'sldkj']
+
+        .. versionchanged:: 3.2.0
+           New ``flatten`` argument.
         """
 
         def flattened(pr):

--- a/pyparsing/testing.py
+++ b/pyparsing/testing.py
@@ -283,6 +283,9 @@ class pyparsing_test:
                               labeled based at 0 (default=True)
 
         :return: str - input string with leading line numbers and column number headers
+
+        .. versionchanged:: 3.2.0
+           New ``indent`` and ``base_1`` arguments.
         """
         if expand_tabs:
             s = s.expandtabs()

--- a/pyparsing/util.py
+++ b/pyparsing/util.py
@@ -425,7 +425,10 @@ def replaced_by_pep8(compat_name: str, fn: C) -> C:
             # )
             return fn(*args, **kwargs)
 
-    _inner.__doc__ = f"""Deprecated - use :class:`{fn.__name__}`"""
+    _inner.__doc__ = f"""
+        .. deprecated:: 3.0.0
+           Use :class:`{fn.__name__}` instead
+        """
     _inner.__name__ = compat_name
     _inner.__annotations__ = fn.__annotations__
     if isinstance(fn, types.FunctionType):


### PR DESCRIPTION
This PR represents a set of tweaks to the project documentation, mostly focused around usability and presentation of information. A lot of it is obviously subjective, and while I personally thing each change is an improvement, I'm not married to any of it and am more than willing to take feedback / remove anything that's not wanted. It's all in very granular commits specifically so that it can easily be adjusted.

### What's here
(Formatted as a checklist, so we can mark off anything to be removed/changed)

- [ ] Turned all of the 3.0.0 "Deprecated" messages into real `.. deprecated::` markup
- [ ] Added `.. versionchanged::` and `.. versionadded::` markup for most of the items in the "what's new in 3.1.0 / 3.2.0" documents (some items don't easily translate into API documentation)
- [ ] Added custom CSS to style the change messages for visibility. It makes use of the relatively-new CSS `:has()` selector to push the `.. deprecated::` styling up to the containing class/function/method/etc. level, so that anything marked deprecated has a red border line running all the way down its left side for maximum visibility. You'll see in screenshots.
   (After some deliberation, I decided not to do the same with added/changed notes, because those won't be "recent" forever and as they age they deserve less prominence. Deprecated features warrant **greater** prominence, if anything, as time passes until they're eventually removed.)
- [ ] Eliminated the unnecessary `docs/modules.rst` document, and made `docs/pyparsing.rst` the top-level index for its own documentation (by putting a hidden `.. toctree::` at the bottom containing only `self`).
- [ ] Moved the documentation from a couple of classes' `__init__`s to the class itself, and removed the `__init__` signatures from the docs entirely, since the construction signatures are shown on the class itself and the `__init__`s become totally redundant, with the documentation moved.
- [ ] Removed the `.. sectnum::`s from the documentation pages, because Sphinx says not to use them, and with good reason -- they're totally broken. Every document gets numbered "1" in the TOC. There are apparently ways to make the sections properly numbered, but `sectnum` isn't it. (I personally don't think it's necessary.)

#### Sphinx configuration changes
- [ ] Leave class/module parents out of the TOC, for readability and to keep them from overflowing into the body text
- [ ] Break longer call signatures (over 100 characters, as currently configured) at each argument for "better" readability; it's still not great but better than one long, sometimes-four-or-five-wrapped-lines continuous signature string.
- [ ] Leave resolvable type names unexpanded in the signatures, which affects some signatures in small ways. (For example, the default `max_matches` argument for `ParserElement.scan_string()` is now listed as `_MAX_INT` instead of `9223372036854775807`.)

#### autodoc configuration changes

- [ ] I changed the `.. automodule::` in `pyparsing.rst` like so:

##### Before
```rst
.. automodule:: pyparsing
    :members:
    :special-members:
    :show-inheritance:
```

##### After
```rst
.. automodule:: pyparsing
    :members:
    :undoc-members:
    :special-members: __add__,__sub__,__div__,__mul__,__and__,__or__,__xor__,__call__,__weakref__,__str__
    :exclude-members: __init__,__repl__,parseImpl,parseImpl_regex,parseImplAsGroupList,parseImplAsMatch,postParse,preParse
    :show-inheritance:
```

Which, obviously, greatly affects the contents of the documentation. But I felt there were a number of undocumented members that were worth showing signatures for, and many special members that _weren't_, so explictly selecting the ones we actually want seemed more productive.

It is a lot of configuration, though, and isn't maintenance-free. (For example, after I added a `.. versionchanged::` to the `__str__` method for `ParseBaseException`, I had to go back and add `__str__` to the `:special-members:` list to get it to show up in the docs.)

So, even more than everything else, explicitly up for debate / open to revision.

I'll follow up with comment(s) showing some side-by-side screenshots, this opening message has gotten  long enough.