### PR TITLE
Docs: Account for wrapping in CSS

### DIFF
--- a/docs/_static/pyparsing.css
+++ b/docs/_static/pyparsing.css
@@ -37,6 +37,14 @@ span.versionmodified {
   line-height: 130%;
 }
 
+div.versionchanged p,
+div.versionadded p {
+  padding-inline-start: 0.5rem;
+}
+span.versionmodified {
+  margin-inline-start: -0.5rem; /* Make up for padding above */
+}
+
 div.versionadded { border-color: #2d67f3; }
 div.versionadded span.added { background-color: #d1e5ff; }
 


### PR DESCRIPTION
A minor fix to the custom CSS for versionadded / versionmodified directives, so that they line up properly when wrapped.

### Before

![image](https://github.com/user-attachments/assets/db7cdf77-fcbe-4f89-abfd-98a63c660e85)

### After

![image](https://github.com/user-attachments/assets/dcf323f0-f1f3-4cc7-b7aa-811b31c10eac)
