### PR TITLE
Add CONTRIBUTING doc to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# CONTRIBUTING
+# Contributing to Pyparsing
 
 Thank you for your interest in working on pyparsing! Pyparsing has become a popular module for creating simple
 text parsing and data scraping applications. It has been incorporated in several widely-used packages, and is

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ release = pyparsing_version
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -48,7 +49,10 @@ templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffixes:
-source_suffix = {'.rst': 'restructuredtext'}
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 # The master toctree document.
 master_doc = "index"
@@ -200,3 +204,5 @@ autodoc_preserve_defaults = True
 autodoc_default_options = {
     'class-doc-from': 'both',
 }
+
+myst_heading_anchors = 3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Release v\ |version|
    whats_new_in_3_1
    whats_new_in_3_0_0
    pyparsing
+   CONTRIBUTING
    CODE_OF_CONDUCT
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 sphinx < 8.2
+myst-parser
+


### PR DESCRIPTION
I'm planning to add a section to the `CONTRIBUTING.md` file about writing doctests for Pyparsing, and as I was doing that thought that it would make sense to make it part of the official documentation as well. So, this PR does that, which involves:

- Enable the `myst_parser` Python package as a Sphinx extension, which enables it to include MarkDown files in the documentation.
- Add `myst_parser` to `docs/requirements.txt` so that it's installed by ReadTheDocs and anyone else looking to build documentation.
- Symlink `CONTRIBUTING.md` into the `docs/` dir (this needs to be tested against ReadTheDocs; it may or may not work)
- Add `CONTRIBUTING` to the `index.rst` toctree.
- Update the title from "CONTRIBUTING" to "Contributing to Pyparsing".

That way, the content is included in the project documentation:

![image](https://github.com/user-attachments/assets/b454d66f-3e44-4d2f-b2b9-975871747cab)

(Assuming ReadTheDocs doesn't balk at the symlink to the parent directory. It'll _proooobably_ be fine.)