### PR TITLE
Documentation: Convert examples to doctests, restore Alabaster theme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,41 +38,49 @@ If you have a question on using pyparsing, there are a number of resources avail
 
 If you have an example you wish to submit, please follow these guidelines.
 
-- **License - Submitted example code must be available for distribution with the rest of pyparsing under the MIT 
+- **License - Submitted example code must be available for distribution with the rest of pyparsing under the MIT
   open source license.**
 
 - Please follow PEP8 name and coding guidelines, and use the black formatter
-  to auto-format code. 
+  to auto-format code.
 
 - Examples should import pyparsing and the common namespace classes as:
 
-      import pyparsing as pp
-      # if necessary
-      ppc = pp.pyparsing_common
-      ppu = pp.pyparsing_unicode
+  ```python
+  import pyparsing as pp
+  # if necessary
+  ppc = pp.pyparsing_common
+  ppu = pp.pyparsing_unicode
+  ```
 
-- Submitted examples *must* be Python 3.6.8 or later compatible. (It is acceptable if examples use Python
-  features added after 3.6)
+- Submitted examples _must_ be Python 3.6.8 or later compatible.
+  (It is acceptable if examples use Python features added after 3.6)
 
 - Where possible use operators to create composite parse expressions:
 
-      expr = expr_a + expr_b | expr_c
+  ```python
+  expr = expr_a + expr_b | expr_c
+  ```
 
   instead of:
 
-      expr = pp.MatchFirst([pp.And([expr_a, expr_b]), expr_c])
+  ```python
+  expr = pp.MatchFirst([pp.And([expr_a, expr_b]), expr_c])
+  ```
 
   Exception: if using a generator to create an expression:
 
-      import keyword
-      python_keywords = keyword.kwlist
-      any_keyword = pp.MatchFirst(pp.Keyword(kw)
-                                  for kw in python_keywords))
+  ```python
+  import keyword
+  python_keywords = keyword.kwlist
+  any_keyword = pp.MatchFirst(pp.Keyword(kw)
+                              for kw in python_keywords))
+  ```
 
-- Learn [Common Pitfalls When Writing Parsers](https://github.com/pyparsing/pyparsing/wiki/Common-Pitfalls-When-Writing-Parsers) and
+- Learn [Common Pitfalls When Writing Parsers][pitfalls] and
   how to avoid them when developing new examples.
 
-- See additional notes under [Some Coding Points](#some-coding-points).
+- See additional notes under [Some coding points](#some-coding-points).
 
 ## Submitting changes
 
@@ -88,11 +96,11 @@ intended on prior versions of Python (currently back to Python 3.6.8).
 
 ## Some design points
 
-- Minimize additions to the module namespace. Over time, pyparsing's namespace has acquired a *lot* of names.
+- Minimize additions to the module namespace. Over time, pyparsing's namespace has acquired a _lot_ of names.
   New features have been encapsulated into namespace classes to try to hold back the name flooding when importing
   pyparsing.
 
-- New operator overloads for ParserElement will need to show broad applicability, and should be related to 
+- New operator overloads for ParserElement will need to show broad applicability, and should be related to
   parser construction.
 
 - Performance tuning should focus on parse time performance. Optimizing parser definition performance is secondary.
@@ -108,28 +116,87 @@ These coding styles are encouraged whether submitting code for core pyparsing or
   name casing. I had just finished several years of Java and Smalltalk development, and camel case seemed to be the
   future trend in coding styles. As of version 3.0.0, pyparsing is moving over to PEP8 naming, while maintaining
   compatibility with existing parser code by defining synonyms using the legacy names. These names will be
-  retained until a future release (probably 4.0), to provide a migration path for current pyparsing-dependent 
+  retained until a future release (probably 4.0), to provide a migration path for current pyparsing-dependent
   applications - DO NOT MODIFY OR REMOVE THESE NAMES.
   See more information at the [PEP8 wiki page](https://github.com/pyparsing/pyparsing/wiki/PEP-8-planning).
 
 - No backslashes for line continuations.
-  Continuation lines for expressions in ()'s should start with the continuing operator:
+  Continuation lines for expressions in `()`'s should start with the continuing operator:
 
-      really_long_line = (something
-                          + some_other_long_thing
-                          + even_another_long_thing)
+  ```python
+  really_long_line = (something
+                      + some_other_long_thing
+                      + even_another_long_thing)
+  ```
 
 - Maximum line length is 120 characters. (Black will override this.)
 
 - Changes to core pyparsing must be compatible back to Py3.6 without conditionalizing. Later Py3 features may be
   used in examples by way of illustration.
 
-- str.format() statements should use named format arguments (unless this proves to be a slowdown at parse time).
+- `str.format()` statements should use named format arguments (unless this proves to be a slowdown at parse time).
 
 - List, tuple, and dict literals should include a trailing comma after the last element, which reduces changeset
   clutter when another element gets added to the end.
 
-- New features should be accompanied by updates to unitTests.py and a bullet in the CHANGES file.
+- New features should be accompanied by updates to `unitTests.py` and a bullet in the CHANGES file.
 
-- Do not modify pyparsing_archive.py. This file is kept as a reference artifact from when pyparsing was distributed
+- Do not modify `pyparsing_archive.py`. This file is kept as a reference artifact from when pyparsing was distributed
   as a single source file.
+
+## Some documentation points
+
+- The docstrings in pyparsing (which are generated into the package's
+  API documentation by Sphinx) make heavy use of doctests for their
+  example code. This allows examples to be tested and verified as
+  working, and ensures that any changes to the code which affect
+  output are accompanied by corresponding changes in the examples.
+
+- The codebase's docstring tests can be verified by running the
+  command `make doctest` from the `docs/` directory. The output
+  should ideally look something like this:
+
+  ```console
+  $ make doctest
+  [...documentation build...]
+  running tests...
+
+  Document: pyparsing
+  -------------------
+  1 item passed all tests:
+   204 tests in default
+  204 tests in 1 item.
+  204 passed.
+  Test passed.
+
+  Document: whats_new_in_3_1
+  --------------------------
+  1 item passed all tests:
+    15 tests in default
+  15 tests in 1 item.
+  15 passed.
+  Test passed.
+
+  Doctest summary
+  ===============
+    219 tests
+      0 failures in tests
+      0 failures in setup code
+      0 failures in cleanup code
+  ```
+
+  Any failed tests will be displayed in detail.
+
+- Much more information about doctests can be found in the
+  [Pyparsing documentation][pyparsing-docs], in the chapter titled
+  "Writing doctest examples". Even if you have never worked with them
+  before, it should guide you through everything you need to know in
+  order to write Pyparsing doctest examples. If you are already familiar
+  with doctests and with `sphinx.ext.doctest` in general, you may wish
+  to skip over the introductory content and go straight to the section
+  on "Doctests in Pyparsing" which covers some issues specific to the
+  project.
+
+<!-- Named hyperlink targets, used in the preceding text -->
+[pitfalls]: https://github.com/pyparsing/pyparsing/wiki/Common-Pitfalls-When-Writing-Parsers
+[pyparsing-docs]: https://pyparsing-docs.readthedocs.io/en/latest/

--- a/docs/Writing_Doctests.rst
+++ b/docs/Writing_Doctests.rst
@@ -1,0 +1,443 @@
+========================
+Writing doctest examples
+========================
+
+Doctest support is provided in Sphinx by the extension
+`sphinx.ext.doctest`_, and its documentation is one
+useful resurce for working with the pyparsing doctests.
+
+.. _sphinx.ext.doctest: https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html
+
+
+Types of doctests
+=================
+
+There are two basic forms of doctest, and both are used extensively
+in the Pyparsing documentation. Which one to use for a given example
+is a decision that needs to be made when writing it, but there are
+some factors that usually make the correct choice an obvious one.
+
+Doctest type 1: ``testcode`` / ``testoutput`` blocks
+----------------------------------------------------
+
+The first form involves one or potentially two separate code blocks.
+The ``testcode`` block contains all of the input code in the form of
+a standard Python script. This can optionally be paired with a
+second ``testoutput`` block, which if present will contain the output
+for the preceding ``testcode`` block.
+
+An example of a ``testcode`` / ``testoutput`` pair, from the docstring
+for ``ParserElement.__add__``:
+
+
+.. code-block:: rst
+
+    Example:
+
+    .. testcode::
+
+        greet = Word(alphas) + "," + Word(alphas) + "!"
+        hello = "Hello, World!"
+        print(hello, "->", greet.parse_string(hello))
+
+    prints:
+
+    .. testoutput::
+
+        Hello, World! -> ['Hello', ',', 'World', '!']
+
+Examples written like this will be formatted in the rendered HTML/Latex/etc.
+documentation **exactly** as if they'd been written as normal code blocks.
+There is no visible difference between the code above and this code without
+doctest support:
+
+.. code-block:: rst
+
+    Example::
+
+        greet = Word(alphas) + "," + Word(alphas) + "!"
+        hello = "Hello, World!"
+        print(hello, "->", greet.parse_string(hello))
+
+    prints::
+
+        Hello, World! -> ['Hello', ',', 'World', '!']
+
+However, the advantage to writing doctests is that when ``make doctest``
+is run from the ``docs/`` directory, the doctest extension will execute
+each ``testcode`` block, and verify that its output exactly matches the
+``testoutput`` block (if present).
+
+Any deviations will be displayed in "ndiff" format. This enhancement
+to the standard unified diff will (sometimes) indicate where in each
+line the differences occur. (The character-difference highlighting is
+frustratingly inconsistent. But at worst ndiff is equivalent to unified
+diff, so it's still worth using.)
+
+Testing examples with doctest allows the code used to demonstrate the
+pyparsing API to be verified against the *actual* API as it's currently
+implemented, and ensures that examples stay current and relevant.
+
+Not all ``testcode`` blocks need a corresponding ``testoutput`` — if a
+``testcode`` block is included on its own, the code inside the block will
+still be executed, but its output won't be verified. This can be useful
+when displaying code that doesn't require demonstration of its output
+(or doesn't output anything), as the extension will still verify that
+the code can be run without error.
+
+It's also possible to include a *hidden* ``testoutput`` block, which will
+beverified against the preceding ``testcode`` but won't be displayed in the
+documentation. To hide a ``testoutput`` block (or a ``testcode`` block,
+for that matter), add the ``:hide:`` option as an argument to the
+directive, i.e.:
+
+.. code-block:: rst
+
+    .. testoutput::
+        :hide:
+
+        """Output that won't be shown, but will be verified against the
+        preceding testcode block."""
+
+Doctest type 2: ``doctest`` interactive blocks
+----------------------------------------------
+
+The second type of doctest is a ``doctest`` block, which takes the form of
+an interactive Python REPL session in standard format (using ``>>>`` and
+``...`` markers for input lines).
+
+With these tests, output is interleaved with the code, which can be much
+easier to follow when there are multiple lines producing output. If an
+example would contains multiple ``print()`` calls, rather than first
+displaying all of the code in a ``testcode`` block, then all of the
+output in a ``testoutput`` block, consider using a ``doctest`` session
+so that the reader can follow along each step as it occurs.
+
+A typical ``doctest`` example can be found in the ``ParserElement.ignore``
+docstring:
+
+.. code-block:: rst
+
+    Example:
+
+    .. doctest::
+
+        >>> patt = Word(alphas)[...]
+        >>> print(patt.parse_string('ablaj /* comment */ lskjd'))
+        ['ablaj']
+
+        >>> patt = Word(alphas)[...].ignore(c_style_comment)
+        >>> print(patt.parse_string('ablaj /* comment */ lskjd'))
+        ['ablaj', 'lskjd']
+
+
+Setup code for doctest blocks
+=============================
+
+The doctest extension is configured with extensive setup code
+which is run before each test block. It can be viewed in the
+:download:`docs/conf.py <../docs/conf.py>` file — look for the
+``doctest_global_setup`` variable near the end of the file.
+
+The setup code is intended to make any useful symbols available
+to the tests without them having to be included in each and every
+doctest block. If additional modules are needed, feel free to add
+them to the global setup. When writing doctests, Pyparsing classes
+can be invoked directly, or as members of the ``pp`` alias namespace.
+Either way, the definition of those symbols can be assumed without
+explicitly importing/defining them.
+
+When using symbols from other aliased namespaces, however, it's a
+good idea to establish the alias for the reader at the start of the
+example code. Even though these are both defined in the global setup,
+showing the establishing lines before referencing ``ppc`` or ``ppu``
+in an example makes that example clearer:
+
+.. code-block: py
+
+    ppc = pp.pyparsing_common
+    ppu = pp.pyparsing_unicode
+
+However, because those symbols *are* provided by default, they don't
+need to be explicitly established for **every** example. Feel free
+to omit them after the first use, when writing multiple examples for
+a given class or function.
+
+Documenting exceptions
+======================
+
+Code that will trigger an exception can be both demonstrated and
+verified using doctests (of either type), although when a ``testoutput``
+block will demonstrate an exception it should be the only output in
+that block — doctest does not support mixing regular output and
+exceptions.
+
+Both the ``IGNORE_EXCEPTION_DETAIL`` and ``ELLIPSIS`` doctest options
+are enabled by default, which make demonstrating exceptions far more
+convenient. Ignoring exception detail means that the full traceback
+for an exception can be omitted, as well as the fully-qualified name
+of the exception class. As long as the ``Traceback...`` line and the
+exception class name match, the doctest will pass. (The exception
+message is also verified by default, but read on for more about that.)
+
+This example code, from the ``ParserElement.set_name`` docstring, will
+actually output a long traceback, followed by an exception of type
+``pyparsing.exceptions.ParseException``. But because the ignore-detail
+option is enabled, the doctest will pass with this abbreviated form:
+
+.. code-block:: rst
+
+    .. doctest::
+
+        >>> integer = Word(nums)
+        >>> integer.parse_string("ABC")
+        Traceback (most recent call last):
+        ParseException: Expected W:(0-9) (at char 0), (line:1, col:1)
+
+Relaxing doctest output validation
+==================================
+
+For even more flexibility in demonstrating output, the ``ELLIPSIS``
+option (enabled by default) means that parts of the output can be
+replaced with an ellipsis (three periods, ``...``) which will validate
+against any output.
+
+This is an extremely useful tool when the exact output of the code is
+unpredictable (for example, when messages include line and column
+numbers, or variable data like the current date or a directory path).
+The code above could also be written like this, and it would still
+pass the doctest:
+
+.. code-block:: rst
+
+    .. doctest::
+
+        >>> integer = Word(nums)
+        >>> integer.parse_string("ABC")
+        Traceback (most recent call last):
+        ParseException: Expected W:(0-9) ...
+
+While this is necessary in some situations, it shouldn't be overused.
+The more precisely a doctest validates the output of its example,
+the more useful it is, so think twice before employing an ellipsis in
+doctest output.
+
+Normalizing whitespace checks
+=============================
+
+Another method of relaxing doctest checks that doesn't impact the
+test's ability to validate output is the ``NORMALIZE_WHITESPACE``
+option. This option isn't enabled by default, but can be turned on
+for any doctest block with a directive argument:
+
+.. code-block::  rst
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
+(Note the preceding ``+`` sign, which adds the option to the default
+set instead of replacing the default options.)
+
+With normalization activated, any combination of spaces, tabs, and
+newlines will compare equal to any other combination.
+
+One advantage this has is permitting long messages to be wrapped
+over several lines in the example output. In this example from the
+``Keyword`` class docstring, the exception message at the end would
+normally be printed as one long line. To make the example readable
+without excessive horizontal scrolling, ``NORMALIZE_WHITESPACE``
+allows the example output to be broken into multiple lines:
+
+.. code-block:: rst
+
+    .. doctest::
+        :options: +NORMALIZE_WHITESPACE
+
+        >>> Keyword("start").parse_string("start")
+        ParseResults(['start'], {})
+        >>> Keyword("start").parse_string("starting")
+        Traceback (most recent call last):
+        ParseException: Expected Keyword 'start',
+        keyword was immediately followed by keyword character,
+        found 'ing'  (at char 5), (line:1, col:6)
+
+Doctests in the Pyparsing codebase
+==================================
+
+While the preceding is generally applicable to doctests in any
+codebase, there are some issues specific to Pyparsing doctests that
+you should be aware of.
+
+``run_tests()`` output
+----------------------
+
+There is one scenario in the pyparsing documentation where the
+``NORMALIZE_WHITESPACE`` option *must* be used.
+
+When the example code uses the ``ParserElement.run_tests()`` method,
+the output will consist of test strings and matches potentially
+separated by two blank lines each. (Unless each test is preceded
+by a comment, then there will be only one blank line.)
+
+Since ReStructuredText will collapse multiple blank lines in embedded
+code, the only way to get the ``run_tests`` output to validate against
+the example is to enable ``NORMALIZE_WHITESPACE`` and collapse the
+multiple blank lines in the expected output, as well.
+
+Also, "any whitespace compares equal" doesn't mean that *no*
+whitespace will be accepted, so the beginning of the ``testoutput``
+block MUST include an extra blank line at the start, in order
+to match the leading 2 (or 1) blank lines in the output.
+
+So, a valid ``run_tests`` output block consists of the ``testoutput``
+directive, the ``:options: +NORMALIZE_WHITESPACE`` argument, then
+**TWO blank lines** followed by the output to be verified. This
+example, from the ``ParserElement.run_tests`` docstring itself,
+demonstrates the required format:
+
+.. code-block:: rst
+    :linenos:
+    :emphasize-lines: 17,21,22,26,27
+
+    Failing example:
+
+    .. testcode::
+
+        number_expr = pyparsing_common.number.copy()
+        result = number_expr.run_tests('''
+            100Z
+            3.14.159
+            ''', failure_tests=True)
+        print("Success" if result[0] else "Failed!")
+
+    prints:
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
+
+        100Z
+        100Z
+        ^
+        ParseException: Expected end of text, found 'Z' ...
+
+        3.14.159
+        3.14.159
+            ^
+        ParseException: Expected end of text, found '.' ...
+        FAIL: Expected end of text, found '.' ...
+        Success
+
+Note in particular:
+
+- The extra blank line (line 17) before the first line of output, which
+  is required to match the *two* blank lines in the actual output.
+
+- Only one blank line (line 22) separating the two tests' output.
+  The real output will again contain two blank lines.
+
+- The use of ellipses to abbreviate the expected output (lines 21, 26, 27).
+
+- Exception messages mixed with normal output.
+
+  In this case that presents no problems, because ``run_tests()`` catches
+  any exceptions generated and prints their messages as normal output.
+  Doctest has no restrictions on normal output, only when the exception
+  is raised and a traceback is triggered.
+
+  By the same token, ``IGNORE_EXCEPTION_DETAIL`` is not applicable here
+  (there are no exceptions in the expected string, only regular output),
+  so the normal string-matching rules apply when comparing expected output
+  to actual output.
+
+Two final notes about failing doctests
+--------------------------------------
+
+There are two things to watch out for, when attempting to address
+doctest failures during a ``make doctest`` run.
+
+Code location references are not useful
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Due to the uncommon structure of the pyparsing namespace (with the
+symbols from all of the package's files imported into the top-level
+``pyparsing`` namespace, and documented there rather than at their
+"home" locations where they're defined), the doctest output for
+failing test will not display the correct source location for the
+code. Every failing test will be preceded by a reference similar to:
+
+.. code-block::
+
+    File "../pyparsing/core.py", line ?, in default
+
+However, this will be followed by a listing of the code that
+produced the failing test. So as long as we write examples
+which are not too generic and are sufficiently distinct from
+each other (which is good practice anyway), it should be easy
+enough to find the failing code.
+
+Diffs on failing tests will include *ALL* differences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``doctest`` displays the NDIFF-format differences between the
+expected output and the actual output, it will indicate **EVERY**
+difference between them — even the differences that would otherwise
+be ignored. The ``IGNORE_TRACEBACK_DETAILS``, ``ELLIPSIS``, and
+``NORMALIZE_WHITESPACE`` options do not apply when NDIFF is generating
+the comparison ouput for a failed test.
+
+What this means is that, even though the NDIFF flags an ellipsized
+section of text as a difference from the actual output, or marks a
+difference where an output line has been split into two when the
+``NORMALIZE_WHITESPACE`` option is enabled, those differences WILL be
+ignored when the doctest is in a passing state. It's important to
+focus on the differences that *wouldn't* otherwise be ignored, and
+just trust that correcting those differences will result in a passing
+test.
+
+For example, consider this failing test:
+
+.. code-block:: shell-session
+    :linenos:
+    :emphasize-lines: 20-23
+
+    $ make doctest
+    ...
+    File "../pyparsing/core.py", line ?, in default
+    Failed example:
+        data_word = Word(alphas)
+        label = data_word + FollowedBy(':')
+
+        attr_expr = (
+            label + Suppress(':')
+            + OneOrMore(data_word, stop_on=label
+        ).set_parse_action(' '.join))
+
+        print(attr_expr.parse_string("color: RED"))
+
+        text = "shape: SQUARE posn: upper left color: light blue texture: burlap"
+
+        # print attributes as plain groups
+        print(attr_expr[1, ...].parse_string(text))
+    Differences (ndiff with -expected +actual):
+        - ['color', "RED"]
+        ?           ^   ^
+        + ['color', 'RED']
+        ?           ^   ^
+        + ['shape', 'SQUARE', 'posn', 'upper left', 'color', 'light blue', 'texture', 'burlap']
+        - ['shape', 'SQUARE',
+        - ... 'texture', 'burlap']
+    **********************************************************************
+    1 item had failures:
+       1 of 208 in default
+    208 tests in 1 item.
+    207 passed and 1 failed.
+    ***Test Failed*** 1 failure.
+
+The **only** significant difference is the highlighted one: The wrong
+quotes used around the word ``"RED"`` in the expected output. Once that's
+changed to ``'RED'``, the doctest will pass. The remaining diff line(s),
+where the expected output uses an ellipsis and is split over two lines
+(with ``NORMALIZE_WHITESPACE`` enabled), will not fail despite being
+shown as differing from the actual output. (Technically it *does* differ,
+after all. The configuration simply ignores that difference.)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ release = pyparsing_version
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
     "myst_parser",
 ]
 
@@ -204,5 +205,16 @@ autodoc_preserve_defaults = True
 autodoc_default_options = {
     'class-doc-from': 'both',
 }
+
+doctest_global_setup = '''
+import string
+import pprint
+import pyparsing
+import pyparsing.common
+ppc = pyparsing.common
+ppu = pyparsing.unicode
+import pyparsing as pp
+from pyparsing import *
+'''
 
 myst_heading_anchors = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import doctest
 import os
 import sys
 
@@ -222,9 +223,9 @@ autodoc_mock_imports = ['railroad']
 autodoc_preserve_defaults = True
 autodoc_default_options = {
     'class-doc-from': 'both',
+    'undoc-members': True,
+    'show-inheritance': True,
 }
-
-import doctest
 
 doctest_global_setup = '''
 import math
@@ -234,6 +235,7 @@ import pyparsing
 import pyparsing.common
 ppc = pyparsing.common
 ppu = pyparsing.unicode
+import pyparsing.util
 import pyparsing as pp
 from pyparsing import *
 '''

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,13 +79,16 @@ pygments_style = "sphinx"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "classic"
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'github_user': 'pyparsing',
+    'github_repo': 'pyparsing',
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -104,7 +107,22 @@ html_css_files = {
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-# html_sidebars = {}
+html_sidebars = {
+    '**': [
+        'about.html',
+        'searchfield.html',
+        'navigation.html',
+        'relations.html',
+        'donate.html',
+    ],
+    'pyparsing': [
+        'about.html',
+        'searchfield.html',
+        'localtoc.html',
+        'relations.html',
+        'donate.html',
+    ],
+}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,6 +224,8 @@ autodoc_default_options = {
     'class-doc-from': 'both',
 }
 
+import doctest
+
 doctest_global_setup = '''
 import string
 import pprint
@@ -234,5 +236,12 @@ ppu = pyparsing.unicode
 import pyparsing as pp
 from pyparsing import *
 '''
+
+doctest_default_flags = (
+    doctest.ELLIPSIS
+    | doctest.IGNORE_EXCEPTION_DETAIL
+    | doctest.DONT_ACCEPT_TRUE_FOR_1
+    | doctest.REPORT_NDIFF
+)
 
 myst_heading_anchors = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,20 +1,20 @@
-#
-# Configuration file for the Sphinx documentation builder.
-#
+"""Configuration file for the Sphinx documentation builder."""
+
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
+# pylint: disable=all
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
 import doctest
 import os
 import sys
 
+# -- Path setup --------------------------------------------------------------
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
 sys.path.insert(0, os.path.abspath(".."))
 
 from pyparsing import __version__ as pyparsing_version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,6 +227,7 @@ autodoc_default_options = {
 import doctest
 
 doctest_global_setup = '''
+import math
 import string
 import pprint
 import pyparsing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Release v\ |version|
    whats_new_in_3_0_0
    pyparsing
    CONTRIBUTING
+   Writing_Doctests
    CODE_OF_CONDUCT
 
 

--- a/docs/pyparsing.rst
+++ b/docs/pyparsing.rst
@@ -1,17 +1,22 @@
+*************
 pyparsing API
-=============
+*************
 
 .. automodule:: pyparsing
     :members:
-    :undoc-members:
     :special-members: __add__,__sub__,__div__,__mul__,__and__,__or__,__xor__,__call__,__weakref__,__str__
     :exclude-members: __init__,__repl__,parseImpl,parseImpl_regex,parseImplAsGroupList,parseImplAsMatch,postParse,preParse
-    :show-inheritance:
+
+Module ``pyparsing.diagram``
+----------------------------
+
+.. automodule:: pyparsing.diagram
+   :members:
 
 .. 'hidden' prevents the toctree from appearing at the bottom of the page
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 2
    :hidden:
 
    self

--- a/docs/pyparsing.rst
+++ b/docs/pyparsing.rst
@@ -4,7 +4,7 @@ pyparsing API
 
 .. automodule:: pyparsing
     :members:
-    :special-members: __add__,__sub__,__div__,__mul__,__and__,__or__,__xor__,__call__,__weakref__,__str__
+    :special-members: __add__,__sub__,__div__,__mul__,__and__,__or__,__xor__,__lshift__,__invert__,__call__,__getitem__,__str__
     :exclude-members: __init__,__repl__,parseImpl,parseImpl_regex,parseImplAsGroupList,parseImplAsMatch,postParse,preParse
 
 Module ``pyparsing.diagram``
@@ -20,4 +20,3 @@ Module ``pyparsing.diagram``
    :hidden:
 
    self
-

--- a/docs/whats_new_in_3_1.rst
+++ b/docs/whats_new_in_3_1.rst
@@ -27,43 +27,45 @@ New Features
   The ``Tag`` element also accepts an optional ``value`` parameter, defaulting to ``True``.
   See the new ``tag_metadata.py`` example in the ``examples`` directory.
 
-  Example::
+  Example:
 
-        # add tag indicating mood
-        end_punc = "." | ("!" + Tag("enthusiastic"))
-        greeting = "Hello" + Word(alphas) + end_punc
+  .. doctest::
 
-        result = greeting.parse_string("Hello World.")
-        print(result.dump())
+     >>> # add tag indicating mood
+     >>> end_punc = "." | ("!" + Tag("enthusiastic"))
+     >>> greeting = "Hello" + Word(alphas) + end_punc
 
-        result = greeting.parse_string("Hello World!")
-        print(result.dump())
+     >>> result = greeting.parse_string("Hello World.")
+     >>> print(result.dump())
+     ['Hello', 'World', '.']
 
-  prints::
-
-        ['Hello', 'World', '.']
-
-        ['Hello', 'World', '!']
-        - enthusiastic: True
+     >>> result = greeting.parse_string("Hello World!")
+     >>> print(result.dump())
+     ['Hello', 'World', '!']
+     - enthusiastic: True
 
 - Extended ``expr[]`` notation for repetition of ``expr`` to accept a
   slice, where the slice's stop value indicates a ``stop_on``
-  expression::
+  expression:
 
-      test = "BEGIN aaa bbb ccc END"
-      BEGIN, END = Keyword.using_each("BEGIN END".split())
-      body_word = Word(alphas)
+  .. testcode::
 
-      # new slice syntax support
-      expr = BEGIN + Group(body_word[...:END]) + END
-      # equivalent to
-      # expr = BEGIN + Group(ZeroOrMore(body_word, stop_on=END)) + END
+     test = "BEGIN aaa bbb ccc END"
+     BEGIN, END = Keyword.using_each("BEGIN END".split())
+     body_word = Word(alphas)
 
-      print(expr.parse_string(test))
+     # new slice syntax support
+     expr = BEGIN + Group(body_word[...:END]) + END
+     # equivalent to
+     # BEGIN + Group(ZeroOrMore(body_word, stop_on=END)) + END
 
-  Prints::
+     print(expr.parse_string(test))
 
-      ['BEGIN', ['aaa', 'bbb', 'ccc'], 'END']
+  Prints:
+
+  .. testoutput::
+
+     ['BEGIN', ['aaa', 'bbb', 'ccc'], 'END']
 
 - Added new class method ``ParserElement.using_each``, to simplify code
   that creates a sequence of ``Literals``, ``Keywords``, or other ``ParserElement``
@@ -81,7 +83,9 @@ New Features
   ``using_each`` will also accept optional keyword args, which it will
   pass through to the class initializer. Here is an expression for
   single-letter variable names that might be used in an algebraic
-  expression::
+  expression:
+
+  .. testcode::
 
       algebra_var = MatchFirst(
           Char.using_each(string.ascii_lowercase, as_keyword=True)
@@ -105,13 +109,17 @@ API Changes
 ===========
 - ``Optional(expr)`` may now be written as ``expr | ""``
 
-  This will make this code::
+  This will make this code:
 
-      "{" + Optional(Literal("A") | Literal("a")) + "}"
+  .. testcode::
 
-  writable as::
+     "{" + Optional(Literal("A") | Literal("a")) + "}"
 
-      "{" + (Literal("A") | Literal("a") | "") + "}"
+  writable as:
+
+  .. testcode::
+
+     "{" + (Literal("A") | Literal("a") | "") + "}"
 
   Some related changes implemented as part of this work:
   - ``Literal("")`` now internally generates an ``Empty()`` (and no longer raises an exception)
@@ -119,16 +127,20 @@ API Changes
 
 - Added new class property ``identifier`` to all Unicode set classes in ``pyparsing.unicode``,
   using the class's values for ``cls.identchars`` and ``cls.identbodychars``. Now Unicode-aware
-  parsers that formerly wrote::
+  parsers that formerly wrote:
 
-      ppu = pyparsing.unicode
-      ident = Word(ppu.Greek.identchars, ppu.Greek.identbodychars)
+  .. testcode::
 
-  can now write::
+     ppu = pyparsing.unicode
+     ident = Word(ppu.Greek.identchars, ppu.Greek.identbodychars)
 
-      ident = ppu.Greek.identifier
-      # or
-      # ident = ppu.Ελληνικά.identifier
+  can now write:
+
+  .. testcode::
+
+     ident = ppu.Greek.identifier
+     # or
+     ident = ppu.Ελληνικά.identifier
 
 - Added bool ``embed`` argument to ``ParserElement.create_diagram()``.
   When passed as True, the resulting diagram will omit the ``<DOCTYPE>``,
@@ -209,11 +221,14 @@ Fixed Bugs
   when specifying ``exact`` argument.
 
 - Fixed bug when parse actions returned an empty string for an expression that
-  had a results name, that the results name was not saved. That is::
+  had a results name, that the results name was not saved. That is:
 
-      expr = Literal("X").add_parse_action(lambda tokens: "")("value")
-      result = expr.parse_string("X")
-      print(result["value"])
+  .. doctest::
+
+     >>> expr = Literal("X").add_parse_action(lambda tokens: "")("value")
+     >>> result = expr.parse_string("X")
+     >>> result["value"]
+     ''
 
   would raise a ``KeyError``. Now empty strings will be saved with the associated
   results name.

--- a/pyparsing/__init__.py
+++ b/pyparsing/__init__.py
@@ -37,7 +37,9 @@ Here is a program to parse "Hello, World!" (or any greeting of the form
 ``"<salutation>, <addressee>!"``), built up using :class:`Word`,
 :class:`Literal`, and :class:`And` elements
 (the :meth:`'+'<ParserElement.__add__>` operators create :class:`And` expressions,
-and the strings are auto-converted to :class:`Literal` expressions)::
+and the strings are auto-converted to :class:`Literal` expressions):
+
+.. testcode::
 
     from pyparsing import Word, alphas
 
@@ -47,7 +49,9 @@ and the strings are auto-converted to :class:`Literal` expressions)::
     hello = "Hello, World!"
     print(hello, "->", greet.parse_string(hello))
 
-The program outputs the following::
+The program outputs the following:
+
+.. testoutput::
 
     Hello, World! -> ['Hello', ',', 'World', '!']
 

--- a/pyparsing/actions.py
+++ b/pyparsing/actions.py
@@ -60,7 +60,7 @@ def replace_with(repl_str: Any) -> ParseAction:
     """
     Helper method for common parse actions that simply return
     a literal value.  Especially useful when used with
-    :class:`transform_string<ParserElement.transform_string>` ().
+    :meth:`~ParserElement.transform_string`.
 
     Example:
 
@@ -77,10 +77,11 @@ def replace_with(repl_str: Any) -> ParseAction:
 
 
 def remove_quotes(s: str, l: int, t: ParseResults) -> Any:
-    """
+    r"""
     Helper parse action for removing quotation marks from parsed
     quoted strings, that use a single character for quoting. For parsing
-    strings that may have multiple characters, use the QuotedString class.
+    strings that may have multiple characters, use the :class:`QuotedString`
+    class.
 
     Example:
 

--- a/pyparsing/actions.py
+++ b/pyparsing/actions.py
@@ -62,13 +62,16 @@ def replace_with(repl_str: Any) -> ParseAction:
     a literal value.  Especially useful when used with
     :class:`transform_string<ParserElement.transform_string>` ().
 
-    Example::
+    Example:
 
-        num = Word(nums).set_parse_action(lambda toks: int(toks[0]))
-        na = one_of("N/A NA").set_parse_action(replace_with(math.nan))
-        term = na | num
+    .. doctest::
 
-        term[1, ...].parse_string("324 234 N/A 234") # -> [324, 234, nan, 234]
+       >>> num = Word(nums).set_parse_action(lambda toks: int(toks[0]))
+       >>> na = one_of("N/A NA").set_parse_action(replace_with(math.nan))
+       >>> term = na | num
+
+       >>> term[1, ...].parse_string("324 234 N/A 234")
+       ParseResults([324, 234, nan, 234], {})
     """
     return lambda s, l, t: [repl_str]
 
@@ -79,14 +82,18 @@ def remove_quotes(s: str, l: int, t: ParseResults) -> Any:
     quoted strings, that use a single character for quoting. For parsing
     strings that may have multiple characters, use the QuotedString class.
 
-    Example::
+    Example:
 
-        # by default, quotation marks are included in parsed results
-        quoted_string.parse_string("'Now is the Winter of our Discontent'") # -> ["'Now is the Winter of our Discontent'"]
+    .. doctest::
 
-        # use remove_quotes to strip quotation marks from parsed results
-        quoted_string.set_parse_action(remove_quotes)
-        quoted_string.parse_string("'Now is the Winter of our Discontent'") # -> ["Now is the Winter of our Discontent"]
+       >>> # by default, quotation marks are included in parsed results
+       >>> quoted_string.parse_string("'Now is the Winter of our Discontent'")
+       ParseResults(["'Now is the Winter of our Discontent'"], {})
+
+       >>> # use remove_quotes to strip quotation marks from parsed results
+       >>> dequoted = quoted_string().set_parse_action(remove_quotes)
+       >>> dequoted.parse_string("'Now is the Winter of our Discontent'")
+       ParseResults(['Now is the Winter of our Discontent'], {})
     """
     return t[0][1:-1]
 
@@ -116,36 +123,53 @@ def with_attribute(*args: tuple[str, str], **attr_dict) -> ParseAction:
     To verify that the attribute exists, but without specifying a value,
     pass ``with_attribute.ANY_VALUE`` as the value.
 
-    Example::
+    The next two examples use the following input data and tag parsers:
 
-        html = '''
-            <div>
-            Some text
-            <div type="grid">1 4 0 1 0</div>
-            <div type="graph">1,3 2,3 1,1</div>
-            <div>this has no type</div>
-            </div>
-        '''
-        div,div_end = make_html_tags("div")
+    .. testcode::
 
-        # only match div tag having a type attribute with value "grid"
-        div_grid = div().set_parse_action(with_attribute(type="grid"))
-        grid_expr = div_grid + SkipTo(div | div_end)("body")
-        for grid_header in grid_expr.search_string(html):
-            print(grid_header.body)
+       html = '''
+           <div>
+           Some text
+           <div type="grid">1 4 0 1 0</div>
+           <div type="graph">1,3 2,3 1,1</div>
+           <div>this has no type</div>
+           </div>
+       '''
+       div,div_end = make_html_tags("div")
 
-        # construct a match with any div tag having a type attribute, regardless of the value
-        div_any_type = div().set_parse_action(with_attribute(type=with_attribute.ANY_VALUE))
-        div_expr = div_any_type + SkipTo(div | div_end)("body")
-        for div_header in div_expr.search_string(html):
-            print(div_header.body)
+    Only match div tag having a type attribute with value "grid":
 
-    prints::
+    .. testcode::
 
-        1 4 0 1 0
+       div_grid = div().set_parse_action(with_attribute(type="grid"))
+       grid_expr = div_grid + SkipTo(div | div_end)("body")
+       for grid_header in grid_expr.search_string(html):
+           print(grid_header.body)
 
-        1 4 0 1 0
-        1,3 2,3 1,1
+    prints:
+
+    .. testoutput::
+
+       1 4 0 1 0
+
+    Construct a match with any div tag having a type attribute,
+    regardless of the value:
+
+    .. testcode::
+
+       div_any_type = div().set_parse_action(
+           with_attribute(type=with_attribute.ANY_VALUE)
+       )
+       div_expr = div_any_type + SkipTo(div | div_end)("body")
+       for div_header in div_expr.search_string(html):
+           print(div_header.body)
+
+    prints:
+
+    .. testoutput::
+
+       1 4 0 1 0
+       1,3 2,3 1,1
     """
     attrs_list: list[tuple[str, str]] = []
     if args:
@@ -172,39 +196,57 @@ with_attribute.ANY_VALUE = object()  # type: ignore [attr-defined]
 
 def with_class(classname: str, namespace: str = "") -> ParseAction:
     """
-    Simplified version of :class:`with_attribute` when
+    Simplified version of :meth:`with_attribute` when
     matching on a div class - made difficult because ``class`` is
     a reserved word in Python.
 
-    Example::
+    Using similar input data to the :meth:`with_attribute` examples:
 
-        html = '''
-            <div>
-            Some text
-            <div class="grid">1 4 0 1 0</div>
-            <div class="graph">1,3 2,3 1,1</div>
-            <div>this &lt;div&gt; has no class</div>
-            </div>
+    .. testcode::
 
-        '''
-        div,div_end = make_html_tags("div")
-        div_grid = div().set_parse_action(with_class("grid"))
+       html = '''
+           <div>
+           Some text
+           <div class="grid">1 4 0 1 0</div>
+           <div class="graph">1,3 2,3 1,1</div>
+           <div>this &lt;div&gt; has no class</div>
+           </div>
+       '''
+       div,div_end = make_html_tags("div")
 
-        grid_expr = div_grid + SkipTo(div | div_end)("body")
-        for grid_header in grid_expr.search_string(html):
-            print(grid_header.body)
+    Only match div tag having the "grid" class:
 
-        div_any_type = div().set_parse_action(with_class(withAttribute.ANY_VALUE))
-        div_expr = div_any_type + SkipTo(div | div_end)("body")
-        for div_header in div_expr.search_string(html):
-            print(div_header.body)
+    .. testcode::
 
-    prints::
+       div_grid = div().set_parse_action(with_class("grid"))
+       grid_expr = div_grid + SkipTo(div | div_end)("body")
+       for grid_header in grid_expr.search_string(html):
+           print(grid_header.body)
 
-        1 4 0 1 0
+    prints:
 
-        1 4 0 1 0
-        1,3 2,3 1,1
+    .. testoutput::
+
+       1 4 0 1 0
+
+    Construct a match with any div tag having a class attribute,
+    regardless of the value:
+
+    .. testcode::
+
+       div_any_type = div().set_parse_action(
+           with_class(withAttribute.ANY_VALUE)
+       )
+       div_expr = div_any_type + SkipTo(div | div_end)("body")
+       for div_header in div_expr.search_string(html):
+           print(div_header.body)
+
+    prints:
+
+    .. testoutput::
+
+       1 4 0 1 0
+       1,3 2,3 1,1
     """
     classattr = f"{namespace}:class" if namespace else "class"
     return with_attribute(**{classattr: classname})

--- a/pyparsing/common.py
+++ b/pyparsing/common.py
@@ -30,7 +30,9 @@ class pyparsing_common:
     - :class:`upcase_tokens`
     - :class:`downcase_tokens`
 
-    Example::
+    Examples:
+
+    .. testcode::
 
         pyparsing_common.number.run_tests('''
             # any int or real number, returned as the appropriate type
@@ -42,44 +44,9 @@ class pyparsing_common:
             1e-12
             ''')
 
-        pyparsing_common.fnumber.run_tests('''
-            # any int or real number, returned as float
-            100
-            -100
-            +100
-            3.14159
-            6.02e23
-            1e-12
-            ''')
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
 
-        pyparsing_common.hex_integer.run_tests('''
-            # hex numbers
-            100
-            FF
-            ''')
-
-        pyparsing_common.fraction.run_tests('''
-            # fractions
-            1/2
-            -3/4
-            ''')
-
-        pyparsing_common.mixed_integer.run_tests('''
-            # mixed fractions
-            1
-            1/2
-            -3/4
-            1-3/4
-            ''')
-
-        import uuid
-        pyparsing_common.uuid.set_parse_action(token_map(uuid.UUID))
-        pyparsing_common.uuid.run_tests('''
-            # uuid
-            12345678-1234-5678-1234-567812345678
-            ''')
-
-    prints::
 
         # any int or real number, returned as the appropriate type
         100
@@ -100,6 +67,22 @@ class pyparsing_common:
         1e-12
         [1e-12]
 
+    .. testcode::
+
+        pyparsing_common.fnumber.run_tests('''
+            # any int or real number, returned as float
+            100
+            -100
+            +100
+            3.14159
+            6.02e23
+            1e-12
+            ''')
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
+
         # any int or real number, returned as float
         100
         [100.0]
@@ -119,6 +102,18 @@ class pyparsing_common:
         1e-12
         [1e-12]
 
+    .. testcode::
+
+        pyparsing_common.hex_integer.run_tests('''
+            # hex numbers
+            100
+            FF
+            ''')
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
+
         # hex numbers
         100
         [256]
@@ -126,12 +121,38 @@ class pyparsing_common:
         FF
         [255]
 
+    .. testcode::
+
+        pyparsing_common.fraction.run_tests('''
+            # fractions
+            1/2
+            -3/4
+            ''')
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
+
         # fractions
         1/2
         [0.5]
 
         -3/4
         [-0.75]
+
+    .. testcode::
+
+        pyparsing_common.mixed_integer.run_tests('''
+            # mixed fractions
+            1
+            1/2
+            -3/4
+            1-3/4
+            ''')
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
 
         # mixed fractions
         1
@@ -145,6 +166,18 @@ class pyparsing_common:
 
         1-3/4
         [1.75]
+    .. testcode::
+
+        import uuid
+        pyparsing_common.uuid.set_parse_action(token_map(uuid.UUID))
+        pyparsing_common.uuid.run_tests('''
+            # uuid
+            12345678-1234-5678-1234-567812345678
+            ''')
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
 
         # uuid
         12345678-1234-5678-1234-567812345678
@@ -264,13 +297,17 @@ class pyparsing_common:
         Params -
         - fmt - format to be passed to datetime.strptime (default= ``"%Y-%m-%d"``)
 
-        Example::
+        Example:
+
+        .. testcode::
 
             date_expr = pyparsing_common.iso8601_date.copy()
             date_expr.set_parse_action(pyparsing_common.convert_to_date())
             print(date_expr.parse_string("1999-12-31"))
 
-        prints::
+        prints:
+
+        .. testoutput::
 
             [datetime.date(1999, 12, 31)]
         """
@@ -291,13 +328,17 @@ class pyparsing_common:
         Params -
         - fmt - format to be passed to datetime.strptime (default= ``"%Y-%m-%dT%H:%M:%S.%f"``)
 
-        Example::
+        Example:
+
+        .. testcode::
 
             dt_expr = pyparsing_common.iso8601_datetime.copy()
             dt_expr.set_parse_action(pyparsing_common.convert_to_datetime())
             print(dt_expr.parse_string("1999-12-31T23:59:59.999"))
 
-        prints::
+        prints:
+
+        .. testoutput::
 
             [datetime.datetime(1999, 12, 31, 23, 59, 59, 999000)]
         """
@@ -329,15 +370,20 @@ class pyparsing_common:
     def strip_html_tags(s: str, l: int, tokens: ParseResults):
         """Parse action to remove HTML tags from web page HTML source
 
-        Example::
+        Example:
+
+        .. testcode::
 
             # strip HTML links from normal text
             text = '<td>More info at the <a href="https://github.com/pyparsing/pyparsing/wiki">pyparsing</a> wiki page</td>'
             td, td_end = make_html_tags("TD")
-            table_text = td + SkipTo(td_end).set_parse_action(pyparsing_common.strip_html_tags)("body") + td_end
+            table_text = td + SkipTo(td_end).set_parse_action(
+                pyparsing_common.strip_html_tags)("body") + td_end
             print(table_text.parse_string(text).body)
 
-        Prints::
+        Prints:
+
+        .. testoutput::
 
             More info at the pyparsing wiki page
         """

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -324,14 +324,15 @@ def condition_as_parse_action(
     """
     Function to convert a simple predicate function that returns ``True`` or ``False``
     into a parse action. Can be used in places when a parse action is required
-    and :class:`ParserElement.add_condition` cannot be used (such as when adding a condition
+    and :meth:`ParserElement.add_condition` cannot be used (such as when adding a condition
     to an operator level in :class:`infix_notation`).
 
     Optional keyword arguments:
 
-    - ``message`` - define a custom message to be used in the raised exception
-    - ``fatal`` - if True, will raise :class:`ParseFatalException` to stop parsing immediately;
-      otherwise will raise :class:`ParseException`
+    :param message: define a custom message to be used in the raised exception
+    :param fatal: if ``True``, will raise :class:`ParseFatalException`
+                  to stop parsing immediately;
+                  otherwise will raise :class:`ParseException`
 
     """
     msg = message if message is not None else "failed user-defined condition"
@@ -398,14 +399,21 @@ class ParserElement(ABC):
         r"""
         Overrides the default whitespace chars
 
-        Example::
+        Example:
+
+        .. doctest::
 
             # default whitespace chars are space, <TAB> and newline
-            Word(alphas)[1, ...].parse_string("abc def\nghi jkl")  # -> ['abc', 'def', 'ghi', 'jkl']
+            >>> Word(alphas)[1, ...].parse_string("abc def\nghi jkl")
+            ParseResults(['abc', 'def', 'ghi', 'jkl'], {})
 
             # change to just treat newline as significant
-            ParserElement.set_default_whitespace_chars(" \t")
-            Word(alphas)[1, ...].parse_string("abc def\nghi jkl")  # -> ['abc', 'def']
+            >>> ParserElement.set_default_whitespace_chars(" \t")
+            >>> Word(alphas)[1, ...].parse_string("abc def\nghi jkl")
+            ParseResults(['abc', 'def'], {})
+
+            # Reset to default
+            >>> ParserElement.set_default_whitespace_chars(" \n\t\r")
         """
         ParserElement.DEFAULT_WHITE_CHARS = chars
 
@@ -419,20 +427,37 @@ class ParserElement(ABC):
         """
         Set class to be used for inclusion of string literals into a parser.
 
-        Example::
+        Example:
+
+        .. doctest::
+            :options: +NORMALIZE_WHITESPACE
 
             # default literal class used is Literal
-            integer = Word(nums)
-            date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
+            >>> integer = Word(nums)
+            >>> date_str = (
+            ...     integer("year") + '/'
+            ...     + integer("month") + '/'
+            ...     + integer("day")
+            ... )
 
-            date_str.parse_string("1999/12/31")  # -> ['1999', '/', '12', '/', '31']
-
+            >>> date_str.parse_string("1999/12/31")
+            ParseResults(['1999', '/', '12', '/', '31'],
+            {'year': '1999', 'month': '12', 'day': '31'})
 
             # change to Suppress
-            ParserElement.inline_literals_using(Suppress)
-            date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
+            >>> ParserElement.inline_literals_using(Suppress)
+            >>> date_str = (
+            ...     integer("year") + '/'
+            ...     + integer("month") + '/'
+            ...     + integer("day")
+            ... )
 
-            date_str.parse_string("1999/12/31")  # -> ['1999', '12', '31']
+            >>> date_str.parse_string("1999/12/31")
+            ParseResults(['1999', '12', '31'],
+            {'year': '1999', 'month': '12', 'day': '31'})
+
+            # Reset
+            >>> ParserElement.inline_literals_using(Literal)
         """
         ParserElement._literalStringClass = cls
 
@@ -441,7 +466,9 @@ class ParserElement(ABC):
         """
         Yields a sequence of ``class(obj, **class_kwargs)`` for obj in seq.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             LPAR, RPAR, LBRACE, RBRACE, SEMI = Suppress.using_each("(){};")
 
@@ -495,14 +522,20 @@ class ParserElement(ABC):
         """
         Suppress warnings emitted for a particular diagnostic on this expression.
 
-        Example::
+        Example:
 
-            base = pp.Forward()
-            base.suppress_warning(Diagnostics.warn_on_parse_using_empty_Forward)
+        .. doctest::
 
-            # statement would normally raise a warning, but is now suppressed
-            print(base.parse_string("x"))
+            >>> label = pp.Word(pp.alphas)
 
+            # Normally using an empty Forward in a grammar
+            # would print a warning, but we can suppress that
+            >>> base = pp.Forward().suppress_warning(
+            ...     pp.Diagnostics.warn_on_parse_using_empty_Forward)
+
+            >>> grammar = base | label
+            >>> print(grammar.parse_string("x"))
+            ['x']
         """
         self.suppress_warnings_.append(warning_type)
         return self
@@ -530,21 +563,34 @@ class ParserElement(ABC):
         different parse actions for the same parsing pattern, using copies of
         the original parse element.
 
-        Example::
+        Example:
 
-            integer = Word(nums).set_parse_action(lambda toks: int(toks[0]))
-            integerK = integer.copy().add_parse_action(lambda toks: toks[0] * 1024) + Suppress("K")
-            integerM = integer.copy().add_parse_action(lambda toks: toks[0] * 1024 * 1024) + Suppress("M")
+        .. testcode::
 
-            print((integerK | integerM | integer)[1, ...].parse_string("5K 100 640K 256M"))
+            integer = Word(nums).set_parse_action(
+                lambda toks: int(toks[0]))
+            integerK = integer.copy().add_parse_action(
+                lambda toks: toks[0] * 1024) + Suppress("K")
+            integerM = integer.copy().add_parse_action(
+                lambda toks: toks[0] * 1024 * 1024) + Suppress("M")
 
-        prints::
+            print(
+                (integerK | integerM | integer)[1, ...].parse_string(
+                "5K 100 640K 256M")
+            )
+
+        prints:
+
+        .. testoutput::
 
             [5120, 100, 655360, 268435456]
 
-        Equivalent form of ``expr.copy()`` is just ``expr()``::
+        Equivalent form of ``expr.copy()`` is just ``expr()``:
 
-            integerM = integer().add_parse_action(lambda toks: toks[0] * 1024 * 1024) + Suppress("M")
+        .. testcode::
+
+            integerM = integer().add_parse_action(
+                lambda toks: toks[0] * 1024 * 1024) + Suppress("M")
         """
         cpy = copy.copy(self)
         cpy.parseAction = self.parseAction[:]
@@ -571,10 +617,12 @@ class ParserElement(ABC):
 
         You can also set results names using the abbreviated syntax,
         ``expr("name")`` in place of ``expr.set_results_name("name")``
-        - see :class:`__call__`. If ``list_all_matches`` is required, use
+        - see :meth:`__call__`. If ``list_all_matches`` is required, use
         ``expr("name*")``.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             integer = Word(nums)
             date_str = (integer.set_results_name("year") + '/'
@@ -647,29 +695,39 @@ class ParserElement(ABC):
 
         Optional keyword arguments:
 
-        - ``call_during_try`` = (default= ``False``) indicate if parse action should be run during
-          lookaheads and alternate testing. For parse actions that have side effects, it is
-          important to only call the parse action once it is determined that it is being
-          called as part of a successful parse. For parse actions that perform additional
-          validation, then call_during_try should be passed as True, so that the validation
-          code is included in the preliminary "try" parses.
+        :param call_during_try: (default= ``False``) indicate if parse action
+                                should be run during lookaheads and alternate
+                                testing. For parse actions that have side
+                                effects, it is important to only call the parse
+                                action once it is determined that it is being
+                                called as part of a successful parse.
+                                For parse actions that perform additional
+                                validation, then ``call_during_try`` should
+                                be passed as True, so that the validation code
+                                is included in the preliminary "try" parses.
 
-        Note: the default parsing behavior is to expand tabs in the input string
-        before starting the parsing process.  See :class:`parse_string` for more
-        information on parsing strings containing ``<TAB>`` s, and suggested
-        methods to maintain a consistent view of the parsed string, the parse
-        location, and line and column positions within the parsed string.
+        .. Note::
+           The default parsing behavior is to expand tabs in the input string
+           before starting the parsing process.
+           See :meth:`parse_string` for more information on parsing strings
+           containing ``<TAB>`` s, and suggested methods to maintain a
+           consistent view of the parsed string, the parse location, and
+           line and column positions within the parsed string.
 
-        Example::
+        Example: Parse dates in the form ``YYYY/MM/DD``
+        -----------------------------------------------
 
-            # parse dates in the form YYYY/MM/DD
+        Setup code:
 
-            # use parse action to convert toks from str to int at parse time
+        .. testcode::
+
             def convert_to_int(toks):
+                '''a parse action to convert toks from str to int
+                at parse time'''
                 return int(toks[0])
 
-            # use a parse action to verify that the date is a valid date
             def is_valid_date(instring, loc, toks):
+                '''a parse action to verify that the date is a valid date'''
                 from datetime import date
                 year, month, day = toks[::2]
                 try:
@@ -684,14 +742,30 @@ class ParserElement(ABC):
             integer.set_parse_action(convert_to_int)
             date_str.set_parse_action(is_valid_date)
 
-            # note that integer fields are now ints, not strings
-            date_str.run_tests('''
-                # successful parse - note that integer fields were converted to ints
-                1999/12/31
+        Successful parse - note that integer fields are converted to ints:
 
-                # fail - invalid date
-                1999/13/31
-                ''')
+        .. testcode::
+
+            print(date_str.parse_string("1999/12/31"))
+            
+        prints:
+
+        .. testoutput::
+
+            [1999, '/', 12, '/', 31]
+
+        Failure - invalid date:
+
+        .. testcode::
+
+            date_str.parse_string("1999/13/31")
+
+        prints:
+
+        .. testoutput::
+
+            Traceback (most recent call last):
+            ParseException: invalid date given, found '1999' ...
         """
         if list(fns) == [None]:
             self.parseAction.clear()
@@ -731,15 +805,20 @@ class ParserElement(ABC):
         - ``call_during_try`` = boolean to indicate if this method should be called during internal tryParse calls,
           default=False
 
-        Example::
+        Example:
 
-            integer = Word(nums).set_parse_action(lambda toks: int(toks[0]))
-            year_int = integer.copy()
-            year_int.add_condition(lambda toks: toks[0] >= 2000, message="Only support years 2000 and later")
-            date_str = year_int + '/' + integer + '/' + integer
+        .. doctest::
+            :options: +NORMALIZE_WHITESPACE
 
-            result = date_str.parse_string("1999/12/31")  # -> Exception: Only support years 2000 and later (at char 0),
-                                                                         (line:1, col:1)
+            >>> integer = Word(nums).set_parse_action(lambda toks: int(toks[0]))
+            >>> year_int = integer.copy().add_condition(
+            ...     lambda toks: toks[0] >= 2000,
+            ...     message="Only support years 2000 and later")
+            >>> date_str = year_int + '/' + integer + '/' + integer
+
+            >>> result = date_str.parse_string("1999/12/31")
+            Traceback (most recent call last):
+            ParseException: Only support years 2000 and later...
         """
         for fn in fns:
             self.parseAction.append(
@@ -1066,17 +1145,26 @@ class ParserElement(ABC):
         repeatedly matched with a fixed recursion depth that is gradually increased
         until finding the longest match.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             import pyparsing as pp
             pp.ParserElement.enable_left_recursion()
 
             E = pp.Forward("E")
             num = pp.Word(pp.nums)
+
             # match `num`, or `num '+' num`, or `num '+' num '+' num`, ...
             E <<= E + '+' - num | num
 
-            print(E.parse_string("1+2+3"))
+            print(E.parse_string("1+2+3+4"))
+
+        prints:
+
+        .. testoutput::
+
+            ['1', '+', '2', '+', '3', '+', '4']
 
         Recursion search naturally memoizes matches of ``Forward`` elements and may
         thus skip reevaluation of parse actions during backtracking. This may break
@@ -1129,6 +1217,8 @@ class ParserElement(ABC):
         program must call the class method :class:`ParserElement.enable_packrat`.
         For best results, call ``enable_packrat()`` immediately after
         importing pyparsing.
+
+        .. Can't really be doctested, alas
 
         Example::
 
@@ -1186,19 +1276,22 @@ class ParserElement(ABC):
 
         By default, partial matches are OK.
 
-        >>> res = Word('a').parse_string('aaaaabaaa')
-        >>> print(res)
-        ['aaaaa']
+        .. doctest::
+
+            >>> res = Word('a').parse_string('aaaaabaaa')
+            >>> print(res)
+            ['aaaaa']
 
         The parsing behavior varies by the inheriting class of this abstract class. Please refer to the children
         directly to see more examples.
 
         It raises an exception if parse_all flag is set and instring does not match the whole grammar.
 
-        >>> res = Word('a').parse_string('aaaaabaaa', parse_all=True)
-        Traceback (most recent call last):
-        ...
-        pyparsing.ParseException: Expected end of text, found 'b'  (at char 5), (line:1, col:6)
+        .. doctest::
+
+            >>> res = Word('a').parse_string('aaaaabaaa', parse_all=True)
+            Traceback (most recent call last):
+            ParseException: Expected end of text, found 'b' ...
         """
         parseAll = parse_all or parseAll
 
@@ -1246,7 +1339,9 @@ class ParserElement(ABC):
         being parsed.  See :class:`parse_string` for more information on parsing
         strings with embedded tabs.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             source = "sldjf123lsdjjkf345sldkjf879lkjsfd987"
             print(source)
@@ -1254,7 +1349,9 @@ class ParserElement(ABC):
                 print(' '*start + '^'*(end-start))
                 print(' '*start + tokens[0])
 
-        prints::
+        prints:
+
+        .. testoutput::
 
             sldjf123lsdjjkf345sldkjf879lkjsfd987
             ^^^^^
@@ -1333,16 +1430,24 @@ class ParserElement(ABC):
         and replace the matched text patterns according to the logic in the parse
         action.  ``transform_string()`` returns the resulting transformed string.
 
-        Example::
+        Example:
+
+        .. testcode::
+
+            quote = '''now is the winter of our discontent,
+            made glorious summer by this sun of york.'''
 
             wd = Word(alphas)
             wd.set_parse_action(lambda toks: toks[0].title())
 
-            print(wd.transform_string("now is the winter of our discontent made glorious summer by this sun of york."))
+            print(wd.transform_string(quote))
 
-        prints::
+        prints:
 
-            Now Is The Winter Of Our Discontent Made Glorious Summer By This Sun Of York.
+        .. testoutput::
+
+            Now Is The Winter Of Our Discontent,
+            Made Glorious Summer By This Sun Of York.
         """
         out: list[str] = []
         lastE = 0
@@ -1388,17 +1493,26 @@ class ParserElement(ABC):
         to match the given parse expression.  May be called with optional
         ``max_matches`` argument, to clip searching after 'n' matches are found.
 
-        Example::
+        Example:
 
-            # a capitalized word starts with an uppercase letter, followed by zero or more lowercase letters
+        .. testcode::
+
+            quote = '''More than Iron, more than Lead,
+            more than Gold I need Electricity'''
+
+            # a capitalized word starts with an uppercase letter,
+            # followed by zero or more lowercase letters
             cap_word = Word(alphas.upper(), alphas.lower())
 
-            print(cap_word.search_string("More than Iron, more than Lead, more than Gold I need Electricity"))
+            print(cap_word.search_string(quote))
 
-            # the sum() builtin can be used to merge results into a single ParseResults object
-            print(sum(cap_word.search_string("More than Iron, more than Lead, more than Gold I need Electricity")))
+            # the sum() builtin can be used to merge results
+            # into a single ParseResults object
+            print(sum(cap_word.search_string(quote)))
 
-        prints::
+        prints:
+
+        .. testoutput::
 
             [['More'], ['Iron'], ['Lead'], ['Gold'], ['I'], ['Electricity']]
             ['More', 'Iron', 'Lead', 'Gold', 'I', 'Electricity']
@@ -1434,12 +1548,17 @@ class ParserElement(ABC):
         and the optional ``include_separators`` argument (default= ``False``), if the separating
         matching text should be included in the split results.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             punc = one_of(list(".,;:/-!?"))
-            print(list(punc.split("This, this?, this sentence, is badly punctuated!")))
+            print(list(punc.split(
+                "This, this?, this sentence, is badly punctuated!")))
 
-        prints::
+        prints:
+
+        .. testoutput::
 
             ['This', ' this', '', ' this sentence', ' is badly punctuated', '']
         """
@@ -1457,21 +1576,29 @@ class ParserElement(ABC):
         Implementation of ``+`` operator - returns :class:`And`. Adding strings to a :class:`ParserElement`
         converts them to :class:`Literal`\\ s by default.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             greet = Word(alphas) + "," + Word(alphas) + "!"
             hello = "Hello, World!"
             print(hello, "->", greet.parse_string(hello))
 
-        prints::
+        prints:
+
+        .. testoutput::
 
             Hello, World! -> ['Hello', ',', 'World', '!']
 
-        ``...`` may be used as a parse expression as a short form of :class:`SkipTo`::
+        ``...`` may be used as a parse expression as a short form of :class:`SkipTo`:
+
+        .. testcode::
 
             Literal('start') + ... + Literal('end')
 
-        is equivalent to::
+        is equivalent to:
+
+        .. testcode::
 
             Literal('start') + SkipTo('end')("_skipped*") + Literal('end')
 
@@ -1754,10 +1881,16 @@ class ParserElement(ABC):
 
         If ``name`` is omitted, same as calling :class:`copy`.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             # these are equivalent
-            userdata = Word(alphas).set_results_name("name") + Word(nums + "-").set_results_name("socsecno")
+            userdata = (
+                Word(alphas).set_results_name("name")
+                + Word(nums + "-").set_results_name("socsecno")
+            )
+
             userdata = Word(alphas)("name") + Word(nums + "-")("socsecno")
         """
         if name is not None:
@@ -1819,15 +1952,17 @@ class ParserElement(ABC):
         matching; may be called repeatedly, to define multiple comment or other
         ignorable patterns.
 
-        Example::
+        Example:
 
-            patt = Word(alphas)[...]
-            patt.parse_string('ablaj /* comment */ lskjd')
-            # -> ['ablaj']
+        .. doctest::
 
-            patt.ignore(c_style_comment)
-            patt.parse_string('ablaj /* comment */ lskjd')
-            # -> ['ablaj', 'lskjd']
+            >>> patt = Word(alphas)[...]
+            >>> print(patt.parse_string('ablaj /* comment */ lskjd'))
+            ['ablaj']
+
+            >>> patt = Word(alphas)[...].ignore(c_style_comment)
+            >>> print(patt.parse_string('ablaj /* comment */ lskjd'))
+            ['ablaj', 'lskjd']
         """
         if isinstance(other, str_type):
             other = Suppress(other)
@@ -1848,14 +1983,32 @@ class ParserElement(ABC):
         """
         Customize display of debugging messages while doing pattern matching:
 
-        - ``start_action`` - method to be called when an expression is about to be parsed;
-          should have the signature ``fn(input_string: str, location: int, expression: ParserElement, cache_hit: bool)``
+        :param start_action: method to be called when an expression is about to be parsed;
+                             should have the signature::
+                             
+                                 fn(input_string: str,
+                                    location: int,
+                                    expression: ParserElement,
+                                    cache_hit: bool)
 
-        - ``success_action`` - method to be called when an expression has successfully parsed;
-          should have the signature ``fn(input_string: str, start_location: int, end_location: int, expression: ParserELement, parsed_tokens: ParseResults, cache_hit: bool)``
+        :param success_action: method to be called when an expression has successfully parsed;
+                               should have the signature::
+                               
+                                   fn(input_string: str,
+                                      start_location: int,
+                                      end_location: int,
+                                      expression: ParserELement,
+                                      parsed_tokens: ParseResults,
+                                      cache_hit: bool)
 
-        - ``exception_action`` - method to be called when expression fails to parse;
-          should have the signature ``fn(input_string: str, location: int, expression: ParserElement, exception: Exception, cache_hit: bool)``
+        :param exception_action: method to be called when expression fails to parse;
+                                 should have the signature::
+                                 
+                                   fn(input_string: str,
+                                      location: int,
+                                      expression: ParserElement,
+                                      exception: Exception,
+                                      cache_hit: bool)
         """
         self.debugActions = self.DebugActions(
             start_action or _default_start_debug_action,  # type: ignore[truthy-function]
@@ -1871,7 +2024,9 @@ class ParserElement(ABC):
         Set ``flag`` to ``True`` to enable, ``False`` to disable.
         Set ``recurse`` to ``True`` to set the debug flag on this expression and all sub-expressions.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             wd = Word(alphas).set_name("alphaword")
             integer = Word(nums).set_name("numword")
@@ -1882,26 +2037,38 @@ class ParserElement(ABC):
 
             term[1, ...].parse_string("abc 123 xyz 890")
 
-        prints::
+        prints:
+
+        .. testoutput::
+            :options: +NORMALIZE_WHITESPACE
 
             Match alphaword at loc 0(1,1)
+              abc 123 xyz 890
+              ^
             Matched alphaword -> ['abc']
-            Match alphaword at loc 3(1,4)
-            Exception raised:Expected alphaword (at char 4), (line:1, col:5)
-            Match alphaword at loc 7(1,8)
+            Match alphaword at loc 4(1,5)
+              abc 123 xyz 890
+                  ^
+            Match alphaword failed, ParseException raised: Expected alphaword, ...
+            Match alphaword at loc 8(1,9)
+              abc 123 xyz 890
+                      ^
             Matched alphaword -> ['xyz']
-            Match alphaword at loc 11(1,12)
-            Exception raised:Expected alphaword (at char 12), (line:1, col:13)
-            Match alphaword at loc 15(1,16)
-            Exception raised:Expected alphaword (at char 15), (line:1, col:16)
+            Match alphaword at loc 12(1,13)
+              abc 123 xyz 890
+                          ^
+            Match alphaword failed, ParseException raised: Expected alphaword, ...
+              abc 123 xyz 890
+                             ^
+            Match alphaword failed, ParseException raised: Expected alphaword, found end of text ...
 
         The output shown is that produced by the default debug actions - custom debug actions can be
-        specified using :class:`set_debug_actions`. Prior to attempting
+        specified using :meth:`set_debug_actions`. Prior to attempting
         to match the ``wd`` expression, the debugging message ``"Match <exprname> at loc <n>(<line>,<col>)"``
         is shown. Then if the parse succeeds, a ``"Matched"`` message is shown, or an ``"Exception raised"``
-        message is shown. Also note the use of :class:`set_name` to assign a human-readable name to the expression,
+        message is shown. Also note the use of :meth:`set_name` to assign a human-readable name to the expression,
         which makes debugging and exception messages easier to understand - for instance, the default
-        name created for the :class:`Word` expression without calling ``set_name`` is ``"W:(A-Za-z)"``.
+        name created for the :class:`Word` expression without calling :meth:`set_name` is ``"W:(A-Za-z)"``.
 
         .. versionchanged:: 3.1.0
            ``recurse`` argument added.
@@ -1942,13 +2109,20 @@ class ParserElement(ABC):
         If `name` is None, clears any custom name for this expression, and clears the
         debug flag is it was enabled via `__diag__.enable_debug_on_named_expressions`.
 
-        Example::
+        Example:
 
-            integer = Word(nums)
-            integer.parse_string("ABC")  # -> Exception: Expected W:(0-9) (at char 0), (line:1, col:1)
+        .. doctest::
 
-            integer.set_name("integer")
-            integer.parse_string("ABC")  # -> Exception: Expected integer (at char 0), (line:1, col:1)
+            >>> integer = Word(nums)
+            >>> integer.parse_string("ABC")
+            Traceback (most recent call last):
+            ParseException: Expected W:(0-9) (at char 0), (line:1, col:1)
+
+            >>> integer.set_name("integer")
+            integer
+            >>> integer.parse_string("ABC")
+            Traceback (most recent call last):
+            ParseException: Expected integer (at char 0), (line:1, col:1)
         
         .. versionchanged:: 3.1.0
            Accept ``None`` as the ``name`` argument.
@@ -2053,15 +2227,16 @@ class ParserElement(ABC):
         Method for quick testing of a parser against a test string. Good for simple
         inline microtests of sub expressions while building up larger parser.
 
-        Parameters:
+        :param test_string: to test against this expression for a match
+        :param parse_all: flag to pass to :meth:`parse_string` when running tests
 
-        - ``test_string`` - to test against this expression for a match
-        - ``parse_all`` - (default= ``True``) - flag to pass to :class:`parse_string` when running tests
+        Example:
 
-        Example::
+        .. doctest::
 
-            expr = Word(nums)
-            assert expr.matches("100")
+            >>> expr = Word(nums)
+            >>> expr.matches("100")
+            True
         """
         parseAll = parseAll and parse_all
         try:
@@ -2117,7 +2292,9 @@ class ParserElement(ABC):
         (or failed if ``failure_tests`` is True), and the results contain a list of lines of each
         test's output
 
-        Example::
+        Passing example:
+
+        .. testcode::
 
             number_expr = pyparsing_common.number.copy()
 
@@ -2130,20 +2307,16 @@ class ParserElement(ABC):
                 6.02e23
                 # integer with scientific notation
                 1e-12
+                # negative decimal number without leading digit
+                -.100
                 ''')
             print("Success" if result[0] else "Failed!")
 
-            result = number_expr.run_tests('''
-                # stray character
-                100Z
-                # missing leading digit before '.'
-                -.100
-                # too many '.'
-                3.14.159
-                ''', failure_tests=True)
-            print("Success" if result[0] else "Failed!")
+        prints:
 
-        prints::
+        .. testoutput::
+            :options: +NORMALIZE_WHITESPACE
+
 
             # unsigned integer
             100
@@ -2161,29 +2334,58 @@ class ParserElement(ABC):
             1e-12
             [1e-12]
 
+            # negative decimal number without leading digit
+            -.100
+            [-0.1]
             Success
+
+        Failure-test example:
+
+        .. testcode::
+
+            result = number_expr.run_tests('''
+                # stray character
+                100Z
+                # too many '.'
+                3.14.159
+                ''', failure_tests=True)
+            print("Success" if result[0] else "Failed!")
+
+        prints:
+
+        .. testoutput::
+            :options: +NORMALIZE_WHITESPACE
+
 
             # stray character
             100Z
+            100Z
                ^
-            FAIL: Expected end of text (at char 3), (line:1, col:4)
-
-            # missing leading digit before '.'
-            -.100
-            ^
-            FAIL: Expected {real number with scientific notation | real number | signed integer} (at char 0), (line:1, col:1)
+            ParseException: Expected end of text, found 'Z' ...
 
             # too many '.'
             3.14.159
+            3.14.159
                 ^
-            FAIL: Expected end of text (at char 4), (line:1, col:5)
-
+            ParseException: Expected end of text, found '.' ...
+            FAIL: Expected end of text, found '.' ...
             Success
 
         Each test string must be on a single line. If you want to test a string that spans multiple
-        lines, create a test like this::
+        lines, create a test like this:
 
+        .. testcode::
+
+            expr = Word(alphanums)[1,...]
             expr.run_tests(r"this is a test\\n of strings that spans \\n 3 lines")
+
+        .. testoutput::
+            :options: +NORMALIZE_WHITESPACE
+            :hide:
+
+
+            this is a test\\n of strings that spans \\n 3 lines
+            ['this', 'is', 'a', 'test', 'of', 'strings', 'that', 'spans', '3', 'lines']
 
         (Note that this is a raw string literal, you must include the leading ``'r'``.)
         """
@@ -2455,11 +2657,17 @@ class Literal(Token):
     """
     Token to exactly match a specified string.
 
-    Example::
+    Example:
 
-        Literal('abc').parse_string('abc')  # -> ['abc']
-        Literal('abc').parse_string('abcdef')  # -> ['abc']
-        Literal('abc').parse_string('ab')  # -> Exception: Expected "abc"
+    .. doctest::
+
+        >>> Literal('abc').parse_string('abc')
+        ParseResults(['abc'], {})
+        >>> Literal('abc').parse_string('abcdef')
+        ParseResults(['abc'], {})
+        >>> Literal('abc').parse_string('ab')
+        Traceback (most recent call last):
+        ParseException: Expected 'abc', found 'ab'  (at char 0), (line: 1, col: 1)
 
     For case-insensitive matching, use :class:`CaselessLiteral`.
 
@@ -2550,10 +2758,25 @@ class Keyword(Token):
       "$"
     - ``caseless`` allows case-insensitive matching, default is ``False``.
 
-    Example::
+    Example:
 
-        Keyword("start").parse_string("start")  # -> ['start']
-        Keyword("start").parse_string("starting")  # -> Exception
+    .. doctest::
+        :options: +NORMALIZE_WHITESPACE
+
+        >>> Keyword("start").parse_string("start")
+        ParseResults(['start'], {})
+        >>> Keyword("start").parse_string("starting")
+        Traceback (most recent call last):
+        ParseException: Expected Keyword 'start', keyword was immediately
+        followed by keyword character, found 'ing'  (at char 5), (line:1, col:6)
+
+    .. doctest::
+        :options: +NORMALIZE_WHITESPACE
+
+        >>> Keyword("start").parse_string("starting").debug()
+        Traceback (most recent call last):
+        ParseException: Expected Keyword "start", keyword was immediately
+        followed by keyword character, found 'ing' ...
 
     For case-insensitive matching, use :class:`CaselessKeyword`.
     """
@@ -2654,10 +2877,12 @@ class CaselessLiteral(Literal):
     Note: the matched results will always be in the case of the given
     match string, NOT the case of the input text.
 
-    Example::
+    Example:
 
-        CaselessLiteral("CMD")[1, ...].parse_string("cmd CMD Cmd10")
-        # -> ['CMD', 'CMD', 'CMD']
+    .. doctest::
+
+        >>> CaselessLiteral("CMD")[1, ...].parse_string("cmd CMD Cmd10")
+        ParseResults(['CMD', 'CMD', 'CMD'], {})
 
     (Contrast with example for :class:`CaselessKeyword`.)
     """
@@ -2679,10 +2904,12 @@ class CaselessKeyword(Keyword):
     """
     Caseless version of :class:`Keyword`.
 
-    Example::
+    Example:
 
-        CaselessKeyword("CMD")[1, ...].parse_string("cmd CMD Cmd10")
-        # -> ['CMD', 'CMD']
+    .. doctest::
+
+        >>> CaselessKeyword("CMD")[1, ...].parse_string("cmd CMD Cmd10")
+        ParseResults(['CMD', 'CMD'], {})
 
     (Contrast with example for :class:`CaselessLiteral`.)
     """
@@ -2721,18 +2948,31 @@ class CloseMatch(Token):
     If ``mismatches`` is an empty list, then the match was an exact
     match.
 
-    Example::
+    Example:
 
-        patt = CloseMatch("ATCATCGAATGGA")
-        patt.parse_string("ATCATCGAAXGGA") # -> (['ATCATCGAAXGGA'], {'mismatches': [[9]], 'original': ['ATCATCGAATGGA']})
-        patt.parse_string("ATCAXCGAAXGGA") # -> Exception: Expected 'ATCATCGAATGGA' (with up to 1 mismatches) (at char 0), (line:1, col:1)
+    .. doctest::
+        :options: +NORMALIZE_WHITESPACE
+
+        >>> patt = CloseMatch("ATCATCGAATGGA")
+        >>> patt.parse_string("ATCATCGAAXGGA")
+        ParseResults(['ATCATCGAAXGGA'],
+        {'original': 'ATCATCGAATGGA', 'mismatches': [9]})
+
+        >>> patt.parse_string("ATCAXCGAAXGGA")
+        Traceback (most recent call last):
+        ParseException: Expected 'ATCATCGAATGGA' (with up to 1 mismatches),
+        found 'ATCAXCGAAXGGA' (at char 0), (line:1, col:1)
 
         # exact match
-        patt.parse_string("ATCATCGAATGGA") # -> (['ATCATCGAATGGA'], {'mismatches': [[]], 'original': ['ATCATCGAATGGA']})
+        >>> patt.parse_string("ATCATCGAATGGA")
+        ParseResults(['ATCATCGAATGGA'],
+        {'original': 'ATCATCGAATGGA', 'mismatches': []})
 
         # close match allowing up to 2 mismatches
-        patt = CloseMatch("ATCATCGAATGGA", max_mismatches=2)
-        patt.parse_string("ATCAXCGAAXGGA") # -> (['ATCAXCGAAXGGA'], {'mismatches': [[4, 9]], 'original': ['ATCATCGAATGGA']})
+        >>> patt = CloseMatch("ATCATCGAATGGA", max_mismatches=2)
+        >>> patt.parse_string("ATCAXCGAAXGGA")
+        ParseResults(['ATCAXCGAAXGGA'],
+        {'original': 'ATCATCGAATGGA', 'mismatches': [4, 9]})
     """
 
     def __init__(
@@ -2823,23 +3063,28 @@ class Word(Token):
 
     pyparsing includes helper strings for building Words:
 
-    - :class:`alphas`
-    - :class:`nums`
-    - :class:`alphanums`
-    - :class:`hexnums`
-    - :class:`alphas8bit` (alphabetic characters in ASCII range 128-255
+    - :attr:`alphas`
+    - :attr:`nums`
+    - :attr:`alphanums`
+    - :attr:`hexnums`
+    - :attr:`alphas8bit` (alphabetic characters in ASCII range 128-255
       - accented, tilded, umlauted, etc.)
-    - :class:`punc8bit` (non-alphabetic characters in ASCII range
+    - :attr:`punc8bit` (non-alphabetic characters in ASCII range
       128-255 - currency, symbols, superscripts, diacriticals, etc.)
-    - :class:`printables` (any non-whitespace character)
+    - :attr:`printables` (any non-whitespace character)
 
     ``alphas``, ``nums``, and ``printables`` are also defined in several
     Unicode sets - see :class:`pyparsing_unicode`.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         # a word composed of digits
-        integer = Word(nums) # equivalent to Word("0123456789") or Word(srange("0-9"))
+        integer = Word(nums)
+        # Two equivalent alternate forms:
+        Word("0123456789")
+        Word(srange("[0-9]"))
 
         # a word with a leading capital, and zero or more lowercase
         capitalized_word = Word(alphas.upper(), alphas.lower())
@@ -2847,7 +3092,8 @@ class Word(Token):
         # hostnames are alphanumeric, with leading alpha, and '-'
         hostname = Word(alphas, alphanums + '-')
 
-        # roman numeral (not a strict parser, accepts invalid mix of characters)
+        # roman numeral
+        # (not a strict parser, accepts invalid mix of characters)
         roman = Word("IVXLCDM")
 
         # any string of non-whitespace characters, except for ','
@@ -3087,7 +3333,9 @@ class Regex(Token):
     `re module <https://docs.python.org/3/library/re.html>`_ module for an
     explanation of the acceptable patterns and flags.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         realnum = Regex(r"[+-]?\d+\.\d*")
         # ref: https://stackoverflow.com/questions/267399/how-do-you-match-only-valid-roman-numerals-with-a-regular-expression
@@ -3096,9 +3344,10 @@ class Regex(Token):
         # named fields in a regex will be returned as named results
         date = Regex(r'(?P<year>\d{4})-(?P<month>\d\d?)-(?P<day>\d\d?)')
 
-        # the Regex class will accept re's compiled using the regex module
-        import regex
-        parser = pp.Regex(regex.compile(r'[0-9]'))
+        # the Regex class will accept regular expressions compiled using the
+        # re module
+        import re
+        parser = pp.Regex(re.compile(r'[0-9]'))
     """
 
     def __init__(
@@ -3250,11 +3499,16 @@ class Regex(Token):
         Return :class:`Regex` with an attached parse action to transform the parsed
         result as if called using `re.sub(expr, repl, string) <https://docs.python.org/3/library/re.html#re.sub>`_.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             make_html = Regex(r"(\w+):(.*?):").sub(r"<\1>\2</\1>")
             print(make_html.transform_string("h1:main title:"))
-            # prints "<h1>main title</h1>"
+
+        .. testoutput::
+
+            <h1>main title</h1>
         """
         if self.asGroupList:
             raise TypeError("cannot use sub() with Regex(as_group_list=True)")
@@ -3304,19 +3558,20 @@ class QuotedString(Token):
     .. caution:: ``convert_whitespace_escapes`` has no effect if
        ``unquote_results`` is ``False``.
 
-    Example::
+    Example:
 
-        qs = QuotedString('"')
-        print(qs.search_string('lsjdf "This is the quote" sldjf'))
-        complex_qs = QuotedString('{{', end_quote_char='}}')
-        print(complex_qs.search_string('lsjdf {{This is the "quote"}} sldjf'))
-        sql_qs = QuotedString('"', esc_quote='""')
-        print(sql_qs.search_string('lsjdf "This is the quote with ""embedded"" quotes" sldjf'))
+    .. doctest::
 
-    prints::
-
+        >>> qs = QuotedString('"')
+        >>> print(qs.search_string('lsjdf "This is the quote" sldjf'))
         [['This is the quote']]
+        >>> complex_qs = QuotedString('{{', end_quote_char='}}')
+        >>> print(complex_qs.search_string(
+        ...    'lsjdf {{This is the "quote"}} sldjf'))
         [['This is the "quote"']]
+        >>> sql_qs = QuotedString('"', esc_quote='""')
+        >>> print(sql_qs.search_string(
+        ...     'lsjdf "This is the quote with ""embedded"" quotes" sldjf'))
         [['This is the quote with "embedded" quotes']]
     """
 
@@ -3526,13 +3781,21 @@ class CharsNotIn(Token):
     ``max`` and ``exact`` are 0, meaning no maximum or exact
     length restriction.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         # define a comma-separated-value as anything that is not a ','
         csv_value = CharsNotIn(',')
-        print(DelimitedList(csv_value).parse_string("dkls,lsdkjf,s12 34,@!#,213"))
+        print(
+            DelimitedList(csv_value).parse_string(
+                "dkls,lsdkjf,s12 34,@!#,213"
+            )
+        )
 
-    prints::
+    prints:
+
+    .. testoutput::
 
         ['dkls', 'lsdkjf', 's12 34', '@!#', '213']
     """
@@ -3720,7 +3983,9 @@ class LineStart(PositionToken):
     r"""Matches if current position is at the beginning of a line within
     the parse string
 
-    Example::
+    Example:
+
+    .. testcode::
 
         test = '''\
         AAA this line
@@ -3732,7 +3997,9 @@ class LineStart(PositionToken):
         for t in (LineStart() + 'AAA' + rest_of_line).search_string(test):
             print(t)
 
-    prints::
+    prints:
+
+    .. testoutput::
 
         ['AAA', ' this line']
         ['AAA', ' and this line']
@@ -3889,25 +4156,23 @@ class Tag(Token):
     processing the parsed results. Accepts an optional tag value,
     defaulting to `True`.
 
-    Example::
+    Example:
 
-        end_punc = "." | ("!" + Tag("enthusiastic"))
-        greeting = "Hello," + Word(alphas) + end_punc
+    .. doctest::
 
-        result = greeting.parse_string("Hello, World.")
-        print(result.dump())
+        >>> end_punc = "." | ("!" + Tag("enthusiastic"))
+        >>> greeting = "Hello," + Word(alphas) + end_punc
 
-        result = greeting.parse_string("Hello, World!")
-        print(result.dump())
-
-    prints::
-
+        >>> result = greeting.parse_string("Hello, World.")
+        >>> print(result.dump())
         ['Hello,', 'World', '.']
 
+        >>> result = greeting.parse_string("Hello, World!")
+        >>> print(result.dump())
         ['Hello,', 'World', '!']
         - enthusiastic: True
 
-    .. versionadded:: 3.1.0
+        .. versionadded:: 3.1.0
     """
 
     def __init__(self, tag_name: str, value: Any = True) -> None:
@@ -4108,7 +4373,9 @@ class And(ParseExpression):
     May also be constructed using the ``'-'`` operator, which will
     suppress backtracking.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         integer = Word(nums)
         name_expr = Word(alphas)[1, ...]
@@ -4274,14 +4541,18 @@ class Or(ParseExpression):
     string will be used. May be constructed using the ``'^'``
     operator.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         # construct Or using '^' operator
 
         number = Word(nums) ^ Combine(Word(nums) + '.' + Word(nums))
         print(number.search_string("123 3.1416 789"))
 
-    prints::
+    prints:
+
+    .. testoutput::
 
         [['123'], ['3.1416'], ['789']]
     """
@@ -4431,17 +4702,19 @@ class MatchFirst(ParseExpression):
     more than one expression matches, the first one listed is the one that will
     match. May be constructed using the ``'|'`` operator.
 
-    Example::
+    Example: Construct MatchFirst using '|' operator
 
-        # construct MatchFirst using '|' operator
+    .. doctest::
 
         # watch the order of expressions to match
-        number = Word(nums) | Combine(Word(nums) + '.' + Word(nums))
-        print(number.search_string("123 3.1416 789")) #  Fail! -> [['123'], ['3'], ['1416'], ['789']]
+        >>> number = Word(nums) | Combine(Word(nums) + '.' + Word(nums))
+        >>> print(number.search_string("123 3.1416 789"))  # Fail!
+        [['123'], ['3'], ['1416'], ['789']]
 
         # put more selective expression first
-        number = Combine(Word(nums) + '.' + Word(nums)) | Word(nums)
-        print(number.search_string("123 3.1416 789")) #  Better -> [['123'], ['3.1416'], ['789']]
+        >>> number = Combine(Word(nums) + '.' + Word(nums)) | Word(nums)
+        >>> print(number.search_string("123 3.1416 789"))  # Better
+        [['123'], ['3.1416'], ['789']]
     """
 
     def __init__(
@@ -4542,7 +4815,9 @@ class Each(ParseExpression):
 
     May be constructed using the ``'&'`` operator.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         color = one_of("RED ORANGE YELLOW GREEN BLUE PURPLE BLACK WHITE BROWN")
         shape_type = one_of("SQUARE CIRCLE TRIANGLE STAR HEXAGON OCTAGON")
@@ -4563,35 +4838,42 @@ class Each(ParseExpression):
             '''
             )
 
-    prints::
+    prints:
+
+    .. testoutput::
+        :options: +NORMALIZE_WHITESPACE
+
 
         shape: SQUARE color: BLACK posn: 100, 120
         ['shape:', 'SQUARE', 'color:', 'BLACK', 'posn:', ['100', ',', '120']]
-        - color: BLACK
+        - color: 'BLACK'
         - posn: ['100', ',', '120']
-          - x: 100
-          - y: 120
-        - shape: SQUARE
-
+          - x: '100'
+          - y: '120'
+        - shape: 'SQUARE'
+        ...
 
         shape: CIRCLE size: 50 color: BLUE posn: 50,80
-        ['shape:', 'CIRCLE', 'size:', '50', 'color:', 'BLUE', 'posn:', ['50', ',', '80']]
-        - color: BLUE
+        ['shape:', 'CIRCLE', 'size:', '50', 'color:', 'BLUE',
+        'posn:', ['50', ',', '80']]
+        - color: 'BLUE'
         - posn: ['50', ',', '80']
-          - x: 50
-          - y: 80
-        - shape: CIRCLE
-        - size: 50
+          - x: '50'
+          - y: '80'
+        - shape: 'CIRCLE'
+        - size: '50'
+        ...
 
-
-        color: GREEN size: 20 shape: TRIANGLE posn: 20,40
-        ['color:', 'GREEN', 'size:', '20', 'shape:', 'TRIANGLE', 'posn:', ['20', ',', '40']]
-        - color: GREEN
+        color:GREEN size:20 shape:TRIANGLE posn:20,40
+        ['color:', 'GREEN', 'size:', '20', 'shape:', 'TRIANGLE',
+        'posn:', ['20', ',', '40']]
+        - color: 'GREEN'
         - posn: ['20', ',', '40']
-          - x: 20
-          - y: 40
-        - shape: TRIANGLE
-        - size: 20
+          - x: '20'
+          - y: '40'
+        - shape: 'TRIANGLE'
+        - size: '20'
+        ...
     """
 
     def __init__(
@@ -4911,23 +5193,26 @@ class AtLineStart(ParseElementEnhance):
     r"""Matches if an expression matches at the beginning of a line within
     the parse string
 
-    Example::
+    Example:
+
+    .. testcode::
 
         test = '''\
-        AAA this line
-        AAA and this line
-          AAA but not this one
-        B AAA and definitely not this one
+        BBB this line
+        BBB and this line
+          BBB but not this one
+        A BBB and definitely not this one
         '''
 
-        for t in (AtLineStart('AAA') + rest_of_line).search_string(test):
+        for t in (AtLineStart('BBB') + rest_of_line).search_string(test):
             print(t)
 
-    prints::
+    prints:
 
-        ['AAA', ' this line']
-        ['AAA', ' and this line']
+    .. testoutput::
 
+        ['BBB', ' this line']
+        ['BBB', ' and this line']
     """
 
     def __init__(self, expr: Union[ParserElement, str]) -> None:
@@ -4949,16 +5234,24 @@ class FollowedBy(ParseElementEnhance):
     in the lookahead expression, those *will* be returned for access by
     name.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         # use FollowedBy to match a label only if it is followed by a ':'
         data_word = Word(alphas)
         label = data_word + FollowedBy(':')
-        attr_expr = Group(label + Suppress(':') + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join))
+        attr_expr = Group(
+            label + Suppress(':')
+            + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join)
+        )
 
-        attr_expr[1, ...].parse_string("shape: SQUARE color: BLACK posn: upper left").pprint()
+        attr_expr[1, ...].parse_string(
+            "shape: SQUARE color: BLACK posn: upper left").pprint()
 
-    prints::
+    prints:
+
+    .. testoutput::
 
         [['shape', 'SQUARE'], ['color', 'BLACK'], ['posn', 'upper left']]
     """
@@ -4998,12 +5291,13 @@ class PrecededBy(ParseElementEnhance):
     give a maximum number of characters to look back from
     the current parse position for a lookbehind match.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         # VB-style variable names with type prefixes
         int_var = PrecededBy("#") + pyparsing_common.identifier
         str_var = PrecededBy("$") + pyparsing_common.identifier
-
     """
 
     def __init__(self, expr: Union[ParserElement, str], retreat: int = 0) -> None:
@@ -5071,18 +5365,21 @@ class Located(ParseElementEnhance):
     Be careful if the input text contains ``<TAB>`` characters, you
     may want to call :class:`ParserElement.parse_with_tabs`
 
-    Example::
+    Example:
+
+    .. testcode::
 
         wd = Word(alphas)
         for match in Located(wd).search_string("ljsdf123lksdjjf123lkkjj1222"):
             print(match)
 
-    prints::
+    prints:
+
+    .. testoutput::
 
         [0, ['ljsdf'], 5]
         [8, ['lksdjjf'], 15]
         [18, ['lkkjj'], 23]
-
     """
 
     def parseImpl(self, instring, loc, do_actions=True) -> ParseImplReturnType:
@@ -5108,7 +5405,9 @@ class NotAny(ParseElementEnhance):
     *not* skip over leading whitespace. ``NotAny`` always returns
     a null token list.  May be constructed using the ``'~'`` operator.
 
-    Example::
+    Example:
+
+    .. testcode::
 
         AND, OR, NOT = map(CaselessKeyword, "AND OR NOT".split())
 
@@ -5230,21 +5529,34 @@ class OneOrMore(_MultipleMatch):
       (only required if the sentinel would ordinarily match the repetition
       expression)
 
-    Example::
+    Example:
 
-        data_word = Word(alphas)
-        label = data_word + FollowedBy(':')
-        attr_expr = Group(label + Suppress(':') + OneOrMore(data_word).set_parse_action(' '.join))
+    .. doctest::
 
-        text = "shape: SQUARE posn: upper left color: BLACK"
-        attr_expr[1, ...].parse_string(text).pprint()  # Fail! read 'color' as data instead of next label -> [['shape', 'SQUARE color']]
+        >>> data_word = Word(alphas)
+        >>> label = data_word + FollowedBy(':')
+        >>> attr_expr = Group(
+        ...     label + Suppress(':')
+        ...     + OneOrMore(data_word).set_parse_action(' '.join))
 
-        # use stop_on attribute for OneOrMore to avoid reading label string as part of the data
-        attr_expr = Group(label + Suppress(':') + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join))
-        OneOrMore(attr_expr).parse_string(text).pprint() # Better -> [['shape', 'SQUARE'], ['posn', 'upper left'], ['color', 'BLACK']]
+        >>> text = "shape: SQUARE posn: upper left color: BLACK"
+
+        # Fail! read 'posn' as data instead of next label
+        >>> attr_expr[1, ...].parse_string(text).pprint()
+        [['shape', 'SQUARE posn']]
+
+        # use stop_on attribute for OneOrMore
+        # to avoid reading label string as part of the data
+        >>> attr_expr = Group(
+        ...     label + Suppress(':')
+        ...     + OneOrMore(
+        ...         data_word, stop_on=label).set_parse_action(' '.join))
+        >>> OneOrMore(attr_expr).parse_string(text).pprint()  # Better
+        [['shape', 'SQUARE'], ['posn', 'upper left'], ['color', 'BLACK']]
 
         # could also be written as
-        (attr_expr * (1,)).parse_string(text).pprint()
+        >>> (attr_expr * (1,)).parse_string(text).pprint()
+        [['shape', 'SQUARE'], ['posn', 'upper left'], ['color', 'BLACK']]
     """
 
     def _generateDefaultName(self) -> str:
@@ -5298,10 +5610,15 @@ class DelimitedList(ParseElementEnhance):
     If ``allow_trailing_delim`` is set to True, then the list may end with
     a delimiter.
 
-    Example::
+    Example:
 
-        DelimitedList(Word(alphas)).parse_string("aa,bb,cc") # -> ['aa', 'bb', 'cc']
-        DelimitedList(Word(hexnums), delim=':', combine=True).parse_string("AA:BB:CC:DD:EE") # -> ['AA:BB:CC:DD:EE']
+    .. doctest::
+
+        >>> DelimitedList(Word(alphas)).parse_string("aa,bb,cc")
+        ParseResults(['aa', 'bb', 'cc'], {})
+        >>> DelimitedList(Word(hexnums), delim=':', combine=True
+        ... ).parse_string("AA:BB:CC:DD:EE")
+        ParseResults(['AA:BB:CC:DD:EE'], {})
 
     .. versionadded:: 3.1.0
     """
@@ -5365,12 +5682,13 @@ class Opt(ParseElementEnhance):
     """
     Optional matching of the given expression.
 
-    Parameters:
+    :param expr: expression that must match zero or more times
+    :param default: (optional) - value to be returned
+                    if the optional expression is not found.
 
-    - ``expr`` - expression that must match zero or more times
-    - ``default`` (optional) - value to be returned if the optional expression is not found.
+    Example:
 
-    Example::
+    .. testcode::
 
         # US postal code can be a 5-digit zip, plus optional 4-digit qualifier
         zip = Combine(Word(nums, exact=5) + Opt('-' + Word(nums, exact=4)))
@@ -5385,7 +5703,11 @@ class Opt(ParseElementEnhance):
             98765-
             ''')
 
-    prints::
+    prints:
+
+    .. testoutput::
+       :options: +NORMALIZE_WHITESPACE
+
 
         # traditional ZIP code
         12345
@@ -5397,8 +5719,10 @@ class Opt(ParseElementEnhance):
 
         # invalid ZIP
         98765-
+        98765-
              ^
-        FAIL: Expected end of text (at char 5), (line:1, col:6)
+        ParseException: Expected end of text, found '-' (at char 5), (line:1, col:6)
+        FAIL: Expected end of text, found '-'  (at char 5), (line:1, col:6)
     """
 
     __optionalNotMatched = _NullToken()
@@ -5445,19 +5769,23 @@ class SkipTo(ParseElementEnhance):
     Token for skipping over all undefined text until the matched
     expression is found.
 
-    Parameters:
+    :param expr: target expression marking the end of the data to be skipped
+    :param include: if ``True``, the target expression is also parsed
+                    (the skipped text and target expression are returned
+                    as a 2-element list) (default= ``False``).
 
-    - ``expr`` - target expression marking the end of the data to be skipped
-    - ``include`` - if ``True``, the target expression is also parsed
-      (the skipped text and target expression are returned as a 2-element
-      list) (default= ``False``).
-    - ``ignore`` - (default= ``None``) used to define grammars (typically quoted strings and
-      comments) that might contain false matches to the target expression
-    - ``fail_on`` - (default= ``None``) define expressions that are not allowed to be
-      included in the skipped test; if found before the target expression is found,
-      the :class:`SkipTo` is not a match
+    :param ignore: (default= ``None``) used to define grammars
+                   (typically quoted strings and comments)
+                   that might contain false matches to the target expression
 
-    Example::
+    :param fail_on: (default= ``None``) define expressions that
+                    are not allowed to be included in the skipped test;
+                    if found before the target expression is found,
+                    the :class:`SkipTo` is not a match
+
+    Example:
+
+    .. testcode::
 
         report = '''
             Outstanding Issues Report - 1 Jan 2000
@@ -5481,9 +5809,11 @@ class SkipTo(ParseElementEnhance):
                       + integer("days_open"))
 
         for tkt in ticket_expr.search_string(report):
-            print tkt.dump()
+            print(tkt.dump())
 
-    prints::
+    prints:
+
+    .. testoutput::
 
         ['101', 'Critical', 'Intermittent system crash', '6']
         - days_open: '6'
@@ -5597,28 +5927,31 @@ class Forward(ParseElementEnhance):
     Forward declaration of an expression to be defined later -
     used for recursive grammars, such as algebraic infix notation.
     When the expression is known, it is assigned to the ``Forward``
-    variable using the ``'<<'`` operator.
+    instance using the ``'<<'`` operator.
 
-    Note: take care when assigning to ``Forward`` not to overlook
-    precedence of operators.
+    .. Note::
 
-    Specifically, ``'|'`` has a lower precedence than ``'<<'``, so that::
+       Take care when assigning to ``Forward`` not to overlook
+       precedence of operators.
 
-        fwd_expr << a | b | c
+       Specifically, ``'|'`` has a lower precedence than ``'<<'``, so that::
 
-    will actually be evaluated as::
+           fwd_expr << a | b | c
 
-        (fwd_expr << a) | b | c
+       will actually be evaluated as::
 
-    thereby leaving b and c out as parseable alternatives.  It is recommended that you
-    explicitly group the values inserted into the ``Forward``::
+           (fwd_expr << a) | b | c
 
-        fwd_expr << (a | b | c)
+       thereby leaving b and c out as parseable alternatives.
+       It is recommended that you explicitly group the values
+       inserted into the :class:`Forward`::
 
-    Converting to use the ``'<<='`` operator instead will avoid this problem.
+           fwd_expr << (a | b | c)
 
-    See :class:`ParseResults.pprint` for an example of a recursive
-    parser created using ``Forward``.
+       Converting to use the ``'<<='`` operator instead will avoid this problem.
+
+    See :meth:`ParseResults.pprint` for an example of a recursive
+    parser created using :class:`Forward`.
     """
 
     def __init__(
@@ -5877,17 +6210,26 @@ class Combine(TokenConverter):
     input string; this can be disabled by specifying
     ``'adjacent=False'`` in the constructor.
 
-    Example::
+    Example:
 
-        real = Word(nums) + '.' + Word(nums)
-        print(real.parse_string('3.1416')) # -> ['3', '.', '1416']
-        # will also erroneously match the following
-        print(real.parse_string('3. 1416')) # -> ['3', '.', '1416']
+    .. doctest::
 
-        real = Combine(Word(nums) + '.' + Word(nums))
-        print(real.parse_string('3.1416')) # -> ['3.1416']
-        # no match when there are internal spaces
-        print(real.parse_string('3. 1416')) # -> Exception: Expected W:(0123...)
+        >>> real = Word(nums) + '.' + Word(nums)
+        >>> print(real.parse_string('3.1416'))
+        ['3', '.', '1416']
+
+        >>> # will also erroneously match the following
+        >>> print(real.parse_string('3. 1416'))
+        ['3', '.', '1416']
+
+        >>> real = Combine(Word(nums) + '.' + Word(nums))
+        >>> print(real.parse_string('3.1416'))
+        ['3.1416']
+
+        >>> # no match when there are internal spaces
+        >>> print(real.parse_string('3. 1416'))
+        Traceback (most recent call last):
+        ParseException: Expected W:(0123...)
     """
 
     def __init__(
@@ -5935,18 +6277,20 @@ class Group(TokenConverter):
     The optional ``aslist`` argument when set to True will return the
     parsed tokens as a Python list instead of a pyparsing ParseResults.
 
-    Example::
+    Example:
 
-        ident = Word(alphas)
-        num = Word(nums)
-        term = ident | num
-        func = ident + Opt(DelimitedList(term))
-        print(func.parse_string("fn a, b, 100"))
-        # -> ['fn', 'a', 'b', '100']
+    .. doctest::
 
-        func = ident + Group(Opt(DelimitedList(term)))
-        print(func.parse_string("fn a, b, 100"))
-        # -> ['fn', ['a', 'b', '100']]
+        >>> ident = Word(alphas)
+        >>> num = Word(nums)
+        >>> term = ident | num
+        >>> func = ident + Opt(DelimitedList(term))
+        >>> print(func.parse_string("fn a, b, 100"))
+        ['fn', 'a', 'b', '100']
+
+        >>> func = ident + Group(Opt(DelimitedList(term)))
+        >>> print(func.parse_string("fn a, b, 100"))
+        ['fn', ['a', 'b', '100']]
     """
 
     def __init__(self, expr: ParserElement, aslist: bool = False) -> None:
@@ -5974,35 +6318,48 @@ class Dict(TokenConverter):
     The optional ``asdict`` argument when set to True will return the
     parsed tokens as a Python dict instead of a pyparsing ParseResults.
 
-    Example::
+    Example:
 
-        data_word = Word(alphas)
-        label = data_word + FollowedBy(':')
+    .. doctest::
 
-        text = "shape: SQUARE posn: upper left color: light blue texture: burlap"
-        attr_expr = (label + Suppress(':') + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join))
+        >>> data_word = Word(alphas)
+        >>> label = data_word + FollowedBy(':')
 
-        # print attributes as plain groups
-        print(attr_expr[1, ...].parse_string(text).dump())
+        >>> attr_expr = (
+        ...     label + Suppress(':')
+        ...     + OneOrMore(data_word, stop_on=label)
+        ...       .set_parse_action(' '.join)
+        ... )
 
-        # instead of OneOrMore(expr), parse using Dict(Group(expr)[1, ...]) - Dict will auto-assign names
-        result = Dict(Group(attr_expr)[1, ...]).parse_string(text)
-        print(result.dump())
+        >>> text = "shape: SQUARE posn: upper left color: light blue texture: burlap"
 
-        # access named fields as dict entries, or output as dict
-        print(result['shape'])
-        print(result.as_dict())
-
-    prints::
-
+        >>> # print attributes as plain groups
+        >>> print(attr_expr[1, ...].parse_string(text).dump())
         ['shape', 'SQUARE', 'posn', 'upper left', 'color', 'light blue', 'texture', 'burlap']
+
+        # instead of OneOrMore(expr), parse using Dict(Group(expr)[1, ...])
+        # Dict will auto-assign names.
+        >>> result = Dict(Group(attr_expr)[1, ...]).parse_string(text)
+        >>> print(result.dump())
         [['shape', 'SQUARE'], ['posn', 'upper left'], ['color', 'light blue'], ['texture', 'burlap']]
         - color: 'light blue'
         - posn: 'upper left'
         - shape: 'SQUARE'
         - texture: 'burlap'
+        [0]:
+          ['shape', 'SQUARE']
+        [1]:
+          ['posn', 'upper left']
+        [2]:
+          ['color', 'light blue']
+        [3]:
+          ['texture', 'burlap']
+
+        # access named fields as dict entries, or output as dict
+        >>> print(result['shape'])
         SQUARE
-        {'color': 'light blue', 'posn': 'upper left', 'texture': 'burlap', 'shape': 'SQUARE'}
+        >>> print(result.as_dict())
+        {'shape': 'SQUARE', 'posn': 'upper left', 'color': 'light blue', 'texture': 'burlap'}
 
     See more examples at :class:`ParseResults` of accessing fields by results name.
     """
@@ -6055,29 +6412,28 @@ class Dict(TokenConverter):
 class Suppress(TokenConverter):
     """Converter for ignoring the results of a parsed expression.
 
-    Example::
+    Example:
 
-        source = "a, b, c,d"
-        wd = Word(alphas)
-        wd_list1 = wd + (',' + wd)[...]
-        print(wd_list1.parse_string(source))
+    .. doctest::
+
+        >>> source = "a, b, c,d"
+        >>> wd = Word(alphas)
+        >>> wd_list1 = wd + (',' + wd)[...]
+        >>> print(wd_list1.parse_string(source))
+        ['a', ',', 'b', ',', 'c', ',', 'd']
 
         # often, delimiters that are useful during parsing are just in the
         # way afterward - use Suppress to keep them out of the parsed output
-        wd_list2 = wd + (Suppress(',') + wd)[...]
-        print(wd_list2.parse_string(source))
+        >>> wd_list2 = wd + (Suppress(',') + wd)[...]
+        >>> print(wd_list2.parse_string(source))
+        ['a', 'b', 'c', 'd']
 
         # Skipped text (using '...') can be suppressed as well
-        source = "lead in START relevant text END trailing text"
-        start_marker = Keyword("START")
-        end_marker = Keyword("END")
-        find_body = Suppress(...) + start_marker + ... + end_marker
-        print(find_body.parse_string(source)
-
-    prints::
-
-        ['a', ',', 'b', ',', 'c', ',', 'd']
-        ['a', 'b', 'c', 'd']
+        >>> source = "lead in START relevant text END trailing text"
+        >>> start_marker = Keyword("START")
+        >>> end_marker = Keyword("END")
+        >>> find_body = Suppress(...) + start_marker + ... + end_marker
+        >>> print(find_body.parse_string(source))
         ['START', 'relevant text ', 'END']
 
     (See also :class:`DelimitedList`.)
@@ -6116,7 +6472,18 @@ def trace_parse_action(f: ParseAction) -> ParseAction:
     When the parse action completes, the decorator will print
     ``"<<"`` followed by the returned value, or any exception that the parse action raised.
 
-    Example::
+    Example:
+
+    .. testsetup:: stderr
+
+        import sys
+        sys.stderr = sys.stdout
+
+    .. testcleanup:: stderr
+
+        sys.stderr = sys.__stderr__
+
+    .. testcode:: stderr
 
         wd = Word(alphas)
 
@@ -6127,9 +6494,13 @@ def trace_parse_action(f: ParseAction) -> ParseAction:
         wds = wd[1, ...].set_parse_action(remove_duplicate_chars)
         print(wds.parse_string("slkdjs sld sldd sdlf sdljf"))
 
-    prints::
+    prints:
 
-        >>entering remove_duplicate_chars(line: 'slkdjs sld sldd sdlf sdljf', 0, (['slkdjs', 'sld', 'sldd', 'sdlf', 'sdljf'], {}))
+    .. testoutput:: stderr
+        :options: +NORMALIZE_WHITESPACE
+
+        >>entering remove_duplicate_chars(line: 'slkdjs sld sldd sdlf sdljf',
+        0, ParseResults(['slkdjs', 'sld', 'sldd', 'sdlf', 'sdljf'], {}))
         <<leaving remove_duplicate_chars (ret: 'dfjkls')
         ['dfjkls']
 

--- a/pyparsing/diagram/__init__.py
+++ b/pyparsing/diagram/__init__.py
@@ -112,9 +112,14 @@ T = TypeVar("T")
 class EachItem(railroad.Group):
     """
     Custom railroad item to compose a:
-    - Group containing a
-      - OneOrMore containing a
-        - Choice of the elements in the Each
+
+    - :class:`railroad.Group` containing a
+
+      - :class:`railroad.OneOrMore` containing a
+
+        - :class:`railroad.Choice` of the elements in the
+          :class:`railroad.Each`
+
     with the group label indicating that all must be matched
     """
 
@@ -152,8 +157,9 @@ class EditablePartial(Generic[T]):
     @classmethod
     def from_call(cls, func: Callable[..., T], *args, **kwargs) -> EditablePartial[T]:
         """
-        If you call this function in the same way that you would call the constructor, it will store the arguments
-        as you expect. For example EditablePartial.from_call(Fraction, 1, 3)() == Fraction(1, 3)
+        If you call this function in the same way that you would call the constructor,
+        it will store the arguments as you expect. For example
+        ``EditablePartial.from_call(Fraction, 1, 3)() == Fraction(1, 3)``
         """
         return EditablePartial(func=func, args=list(args), kwargs=kwargs)
 
@@ -179,7 +185,9 @@ class EditablePartial(Generic[T]):
 
 def railroad_to_html(diagrams: list[NamedDiagram], embed=False, **kwargs) -> str:
     """
-    Given a list of NamedDiagram, produce a single HTML string that visualises those diagrams
+    Given a list of :class:`NamedDiagram`, produce a single HTML string
+    that visualises those diagrams.
+
     :params kwargs: kwargs to be passed in to the template
     """
     data = []
@@ -231,16 +239,22 @@ def to_railroad(
     """
     Convert a pyparsing element tree into a list of diagrams. This is the recommended entrypoint to diagram
     creation if you want to access the Railroad tree before it is converted to HTML
+
     :param element: base element of the parser being diagrammed
-    :param diagram_kwargs: kwargs to pass to the Diagram() constructor
-    :param vertical: (optional) - int - limit at which number of alternatives should be
-       shown vertically instead of horizontally
-    :param show_results_names - bool to indicate whether results name annotations should be
-       included in the diagram
-    :param show_groups - bool to indicate whether groups should be highlighted with an unlabeled
-       surrounding box
-    :param show_hidden - bool to indicate whether internal elements that are typically hidden
-       should be shown
+
+    :param diagram_kwargs: kwargs to pass to the :meth:`Diagram` constructor
+
+    :param vertical: (optional) int - limit at which number of alternatives
+        should be shown vertically instead of horizontally
+
+    :param show_results_names: bool to indicate whether results name
+        annotations should be included in the diagram
+
+    :param show_groups: bool to indicate whether groups should be highlighted
+        with an unlabeled surrounding box
+
+    :param show_hidden: bool to indicate whether internal elements that are
+        typically hidden should be shown
     """
     # Convert the whole tree underneath the root
     lookup = ConverterState(diagram_kwargs=diagram_kwargs or {})

--- a/pyparsing/exceptions.py
+++ b/pyparsing/exceptions.py
@@ -239,7 +239,9 @@ class ParseBaseException(Exception):
         Returns a multi-line string listing the ParserElements and/or function names in the
         exception's stack trace.
 
-        Example::
+        Example:
+
+        .. testcode::
 
             # an expression to parse 3 integers
             expr = pp.Word(pp.nums) * 3
@@ -249,11 +251,13 @@ class ParseBaseException(Exception):
             except pp.ParseException as pe:
                 print(pe.explain(depth=0))
 
-        prints::
+        prints:
+
+        .. testoutput::
 
             123 456 A789
                     ^
-            ParseException: Expected W:(0-9), found 'A'  (at char 8), (line:1, col:9)
+            ParseException: Expected W:(0-9), found 'A789'  (at char 8), (line:1, col:9)
 
         Note: the diagnostic output will include string representations of the expressions
         that failed to parse. These representations will be more helpful if you use `set_name` to
@@ -276,7 +280,9 @@ class ParseException(ParseBaseException):
     """
     Exception thrown when a parse expression doesn't match the input string
 
-    Example::
+    Example:
+
+    .. testcode::
 
         integer = Word(nums).set_name("integer")
         try:
@@ -284,7 +290,9 @@ class ParseException(ParseBaseException):
         except ParseException as pe:
             print(pe, f"column: {pe.column}")
 
-    prints::
+    prints:
+
+    .. testoutput::
 
        Expected integer, found 'ABC'  (at char 0), (line:1, col:1) column: 1
 

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -38,27 +38,38 @@ def counted_array(
     If ``int_expr`` is specified, it should be a pyparsing expression
     that produces an integer value.
 
-    Example::
+    Examples:
 
-        counted_array(Word(alphas)).parse_string('2 ab cd ef')  # -> ['ab', 'cd']
+    .. doctest::
 
-        # in this parser, the leading integer value is given in binary,
-        # '10' indicating that 2 values are in the array
-        binary_constant = Word('01').set_parse_action(lambda t: int(t[0], 2))
-        counted_array(Word(alphas), int_expr=binary_constant).parse_string('10 ab cd ef')  # -> ['ab', 'cd']
+        >>> counted_array(Word(alphas)).parse_string('2 ab cd ef')
+        ParseResults(['ab', 'cd'], {})
 
-        # if other fields must be parsed after the count but before the
-        # list items, give the fields results names and they will
-        # be preserved in the returned ParseResults:
-        count_with_metadata = integer + Word(alphas)("type")
-        typed_array = counted_array(Word(alphanums), int_expr=count_with_metadata)("items")
-        result = typed_array.parse_string("3 bool True True False")
-        print(result.dump())
+    - In this parser, the leading integer value is given in binary,
+      '10' indicating that 2 values are in the array:
 
-        # prints
-        # ['True', 'True', 'False']
-        # - items: ['True', 'True', 'False']
-        # - type: 'bool'
+      .. doctest::
+
+        >>> binary_constant = Word('01').set_parse_action(lambda t: int(t[0], 2))
+        >>> counted_array(Word(alphas), int_expr=binary_constant
+        ...     ).parse_string('10 ab cd ef')
+        ParseResults(['ab', 'cd'], {})
+
+    - If other fields must be parsed after the count but before the
+      list items, give the fields results names and they will
+      be preserved in the returned ParseResults:
+
+      .. doctest::
+
+         >>> ppc = pyparsing.common
+         >>> count_with_metadata = ppc.integer + Word(alphas)("type")
+         >>> typed_array = counted_array(Word(alphanums),
+         ...     int_expr=count_with_metadata)("items")
+         >>> result = typed_array.parse_string("3 bool True True False")
+         >>> print(result.dump())
+         ['True', 'True', 'False']
+         - items: ['True', 'True', 'False']
+         - type: 'bool'
     """
     intExpr = intExpr or int_expr
     array_expr = Forward()
@@ -84,9 +95,11 @@ def match_previous_literal(expr: ParserElement) -> ParserElement:
     the tokens matched in a previous expression, that is, it looks for
     a 'repeat' of a previous expression.  For example::
 
-        first = Word(nums)
-        second = match_previous_literal(first)
-        match_expr = first + ":" + second
+    .. testcode::
+
+       first = Word(nums)
+       second = match_previous_literal(first)
+       match_expr = first + ":" + second
 
     will match ``"1:1"``, but not ``"1:2"``.  Because this
     matches a previous literal, will also match the leading
@@ -117,11 +130,13 @@ def match_previous_literal(expr: ParserElement) -> ParserElement:
 def match_previous_expr(expr: ParserElement) -> ParserElement:
     """Helper to define an expression that is indirectly defined from
     the tokens matched in a previous expression, that is, it looks for
-    a 'repeat' of a previous expression.  For example::
+    a 'repeat' of a previous expression.  For example:
 
-        first = Word(nums)
-        second = match_previous_expr(first)
-        match_expr = first + ":" + second
+    .. testcode::
+
+       first = Word(nums)
+       second = match_previous_expr(first)
+       match_expr = first + ":" + second
 
     will match ``"1:1"``, but not ``"1:2"``.  Because this
     matches by expressions, will *not* match the leading ``"1:1"``
@@ -164,32 +179,35 @@ def one_of(
     regardless of the input order, but returns
     a :class:`MatchFirst` for best performance.
 
-    Parameters:
+    :param strs: a string of space-delimited literals, or a collection of
+       string literals
+    :param caseless: treat all literals as caseless
+    :param use_regex: bool - as an optimization, will
+       generate a :class:`Regex` object; otherwise, will generate
+       a :class:`MatchFirst` object (if ``caseless=True`` or
+       ``as_keyword=True``, or if creating a :class:`Regex` raises an exception)
+    :param as_keyword: bool - enforce :class:`Keyword`-style matching on the
+       generated expressions
+    
+    Parameters ``asKeyword`` and ``useRegex`` are retained for pre-PEP8
+    compatibility, but will be removed in a future release.
 
-    - ``strs`` - a string of space-delimited literals, or a collection of
-      string literals
-    - ``caseless`` - treat all literals as caseless - (default= ``False``)
-    - ``use_regex`` - as an optimization, will
-      generate a :class:`Regex` object; otherwise, will generate
-      a :class:`MatchFirst` object (if ``caseless=True`` or ``as_keyword=True``, or if
-      creating a :class:`Regex` raises an exception) - (default= ``True``)
-    - ``as_keyword`` - enforce :class:`Keyword`-style matching on the
-      generated expressions - (default= ``False``)
-    - ``asKeyword`` and ``useRegex`` are retained for pre-PEP8 compatibility,
-      but will be removed in a future release
+    Example:
 
-    Example::
+    .. testcode::
 
-        comp_oper = one_of("< = > <= >= !=")
-        var = Word(alphas)
-        number = Word(nums)
-        term = var | number
-        comparison_expr = term + comp_oper + term
-        print(comparison_expr.search_string("B = 12  AA=23 B<=AA AA>12"))
+       comp_oper = one_of("< = > <= >= !=")
+       var = Word(alphas)
+       number = Word(nums)
+       term = var | number
+       comparison_expr = term + comp_oper + term
+       print(comparison_expr.search_string("B = 12  AA=23 B<=AA AA>12"))
 
-    prints::
+    prints:
 
-        [['B', '=', '12'], ['AA', '=', '23'], ['B', '<=', 'AA'], ['AA', '>', '12']]
+    .. testoutput::
+
+       [['B', '=', '12'], ['AA', '=', '23'], ['B', '<=', 'AA'], ['AA', '>', '12']]
     """
     asKeyword = asKeyword or as_keyword
     useRegex = useRegex and use_regex
@@ -293,32 +311,49 @@ def dict_of(key: ParserElement, value: ParserElement) -> Dict:
     pattern can include named results, so that the :class:`Dict` results
     can include named token fields.
 
-    Example::
+    Example:
 
-        text = "shape: SQUARE posn: upper left color: light blue texture: burlap"
-        attr_expr = (label + Suppress(':') + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join))
-        print(attr_expr[1, ...].parse_string(text).dump())
+    .. doctest::
 
-        attr_label = label
-        attr_value = Suppress(':') + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join)
+       >>> text = "shape: SQUARE posn: upper left color: light blue texture: burlap"
+       
+       >>> data_word = Word(alphas)
+       >>> label = data_word + FollowedBy(':')
+       >>> attr_expr = (
+       ...    label
+       ...    + Suppress(':')
+       ...    + OneOrMore(data_word, stop_on=label)
+       ...    .set_parse_action(' '.join))
+       >>> print(attr_expr[1, ...].parse_string(text).dump())
+       ['shape', 'SQUARE', 'posn', 'upper left', 'color', 'light blue', 'texture', 'burlap']
 
-        # similar to Dict, but simpler call format
-        result = dict_of(attr_label, attr_value).parse_string(text)
-        print(result.dump())
-        print(result['shape'])
-        print(result.shape)  # object attribute access works too
-        print(result.as_dict())
+       >>> attr_label = label
+       >>> attr_value = Suppress(':') + OneOrMore(data_word, stop_on=label
+       ...   ).set_parse_action(' '.join)
 
-    prints::
+       # similar to Dict, but simpler call format
+       >>> result = dict_of(attr_label, attr_value).parse_string(text)
+       >>> print(result.dump())
+       [['shape', 'SQUARE'], ['posn', 'upper left'], ['color', 'light blue'], ['texture', 'burlap']]
+       - color: 'light blue'
+       - posn: 'upper left'
+       - shape: 'SQUARE'
+       - texture: 'burlap'
+       [0]:
+         ['shape', 'SQUARE']
+       [1]:
+         ['posn', 'upper left']
+       [2]:
+         ['color', 'light blue']
+       [3]:
+         ['texture', 'burlap']
 
-        [['shape', 'SQUARE'], ['posn', 'upper left'], ['color', 'light blue'], ['texture', 'burlap']]
-        - color: 'light blue'
-        - posn: 'upper left'
-        - shape: 'SQUARE'
-        - texture: 'burlap'
-        SQUARE
-        SQUARE
-        {'color': 'light blue', 'shape': 'SQUARE', 'posn': 'upper left', 'texture': 'burlap'}
+       >>> print(result['shape'])
+       SQUARE
+       >>> print(result.shape)  # object attribute access works too
+       SQUARE
+       >>> print(result.as_dict())
+       {'shape': 'SQUARE', 'posn': 'upper left', 'color': 'light blue', 'texture': 'burlap'}
     """
     return Dict(OneOrMore(Group(key + value)))
 
@@ -344,18 +379,22 @@ def original_text_for(
     The ``asString`` pre-PEP8 argument is retained for compatibility,
     but will be removed in a future release.
 
-    Example::
+    Example:
 
-        src = "this is test <b> bold <i>text</i> </b> normal text "
-        for tag in ("b", "i"):
-            opener, closer = make_html_tags(tag)
-            patt = original_text_for(opener + ... + closer)
-            print(patt.search_string(src)[0])
+    .. testcode::
 
-    prints::
+       src = "this is test <b> bold <i>text</i> </b> normal text "
+       for tag in ("b", "i"):
+           opener, closer = make_html_tags(tag)
+           patt = original_text_for(opener + ... + closer)
+           print(patt.search_string(src)[0])
 
-        ['<b> bold <i>text</i> </b>']
-        ['<i>text</i>']
+    prints:
+
+    .. testoutput::
+
+       ['<b> bold <i>text</i> </b>']
+       ['<i>text</i>']
     """
     asString = asString and as_string
 
@@ -398,19 +437,24 @@ def locatedExpr(expr: ParserElement) -> ParserElement:
     - ``value`` - the actual parsed results
 
     Be careful if the input text contains ``<TAB>`` characters, you
-    may want to call :class:`ParserElement.parse_with_tabs`
+    may want to call :meth:`ParserElement.parse_with_tabs`
 
-    Example::
+    Example:
 
-        wd = Word(alphas)
-        for match in locatedExpr(wd).search_string("ljsdf123lksdjjf123lkkjj1222"):
-            print(match)
+    .. testcode::
 
-    prints::
+       wd = Word(alphas)
+       res = locatedExpr(wd).search_string("ljsdf123lksdjjf123lkkjj1222")
+       for match in res:
+           print(match)
 
-        [[0, 'ljsdf', 5]]
-        [[8, 'lksdjjf', 15]]
-        [[18, 'lkkjj', 23]]
+    prints:
+
+    .. testoutput::
+
+       [[0, 'ljsdf', 5]]
+       [[8, 'lksdjjf', 15]]
+       [[18, 'lkkjj', 23]]
     """
     locator = Empty().set_parse_action(lambda ss, ll, tt: ll)
     return Group(
@@ -436,18 +480,19 @@ def nested_expr(
     """Helper method for defining nested lists enclosed in opening and
     closing delimiters (``"("`` and ``")"`` are the default).
 
-    Parameters:
+    :param opener: str - opening character for a nested list
+       (default= ``"("``); can also be a pyparsing expression
 
-    - ``opener`` - opening character for a nested list
-      (default= ``"("``); can also be a pyparsing expression
-    - ``closer`` - closing character for a nested list
-      (default= ``")"``); can also be a pyparsing expression
-    - ``content`` - expression for items within the nested lists
-      (default= ``None``)
-    - ``ignore_expr`` - expression for ignoring opening and closing delimiters
-      (default= :class:`quoted_string`)
-    - ``ignoreExpr`` - this pre-PEP8 argument is retained for compatibility
-      but will be removed in a future release
+    :param closer: str - closing character for a nested list
+       (default= ``")"``); can also be a pyparsing expression
+
+    :param content: expression for items within the nested lists
+
+    :param ignore_expr: expression for ignoring opening and closing delimiters
+       (default = :class:`quoted_string`)
+
+    Parameter ``ignoreExpr`` is retained for compatibility
+    but will be removed in a future release.
 
     If an expression is not provided for the content argument, the
     nested expression will capture all whitespace-delimited content
@@ -461,44 +506,48 @@ def nested_expr(
     :class:`quoted_string`, but if no expressions are to be ignored, then
     pass ``None`` for this argument.
 
-    Example::
+    Example:
 
-        data_type = one_of("void int short long char float double")
-        decl_data_type = Combine(data_type + Opt(Word('*')))
-        ident = Word(alphas+'_', alphanums+'_')
-        number = pyparsing_common.number
-        arg = Group(decl_data_type + ident)
-        LPAR, RPAR = map(Suppress, "()")
+    .. testcode::
 
-        code_body = nested_expr('{', '}', ignore_expr=(quoted_string | c_style_comment))
+       data_type = one_of("void int short long char float double")
+       decl_data_type = Combine(data_type + Opt(Word('*')))
+       ident = Word(alphas+'_', alphanums+'_')
+       number = pyparsing_common.number
+       arg = Group(decl_data_type + ident)
+       LPAR, RPAR = map(Suppress, "()")
 
-        c_function = (decl_data_type("type")
-                      + ident("name")
-                      + LPAR + Opt(DelimitedList(arg), [])("args") + RPAR
-                      + code_body("body"))
-        c_function.ignore(c_style_comment)
+       code_body = nested_expr('{', '}', ignore_expr=(quoted_string | c_style_comment))
 
-        source_code = '''
-            int is_odd(int x) {
-                return (x%2);
-            }
+       c_function = (decl_data_type("type")
+                     + ident("name")
+                     + LPAR + Opt(DelimitedList(arg), [])("args") + RPAR
+                     + code_body("body"))
+       c_function.ignore(c_style_comment)
 
-            int dec_to_hex(char hchar) {
-                if (hchar >= '0' && hchar <= '9') {
-                    return (ord(hchar)-ord('0'));
-                } else {
-                    return (10+ord(hchar)-ord('A'));
-                }
-            }
-        '''
-        for func in c_function.search_string(source_code):
-            print("%(name)s (%(type)s) args: %(args)s" % func)
+       source_code = '''
+           int is_odd(int x) {
+               return (x%2);
+           }
+
+           int dec_to_hex(char hchar) {
+               if (hchar >= '0' && hchar <= '9') {
+                   return (ord(hchar)-ord('0'));
+               } else {
+                   return (10+ord(hchar)-ord('A'));
+               }
+           }
+       '''
+       for func in c_function.search_string(source_code):
+           print(f"{func.name} ({func.type}) args: {func.args}")
 
 
-    prints::
+    prints:
 
-        is_odd (int) args: [['int', 'x']]
-        dec_to_hex (int) args: [['char', 'hchar']]
+    .. testoutput::
+
+       is_odd (int) args: [['int', 'x']]
+       dec_to_hex (int) args: [['char', 'hchar']]
     """
     if ignoreExpr != ignore_expr:
         ignoreExpr = ignore_expr if ignoreExpr is _NO_IGNORE_EXPR_GIVEN else ignoreExpr
@@ -576,7 +625,8 @@ def nested_expr(
 
 
 def _makeTags(tagStr, xml, suppress_LT=Suppress("<"), suppress_GT=Suppress(">")):
-    """Internal helper to construct opening and closing tag expressions, given a tag name"""
+    """Internal helper to construct opening and closing tag expressions,
+    given a tag name"""
     if isinstance(tagStr, str_type):
         resname = tagStr
         tagStr = Keyword(tagStr, caseless=not xml)
@@ -640,22 +690,26 @@ def make_html_tags(
     given a tag name. Matches tags in either upper or lower case,
     attributes with namespaces and with quoted or unquoted values.
 
-    Example::
+    Example:
 
-        text = '<td>More info at the <a href="https://github.com/pyparsing/pyparsing/wiki">pyparsing</a> wiki page</td>'
-        # make_html_tags returns pyparsing expressions for the opening and
-        # closing tags as a 2-tuple
-        a, a_end = make_html_tags("A")
-        link_expr = a + SkipTo(a_end)("link_text") + a_end
+    .. testcode::
 
-        for link in link_expr.search_string(text):
-            # attributes in the <A> tag (like "href" shown here) are
-            # also accessible as named results
-            print(link.link_text, '->', link.href)
+       text = '<td>More info at the <a href="https://github.com/pyparsing/pyparsing/wiki">pyparsing</a> wiki page</td>'
+       # make_html_tags returns pyparsing expressions for the opening and
+       # closing tags as a 2-tuple
+       a, a_end = make_html_tags("A")
+       link_expr = a + SkipTo(a_end)("link_text") + a_end
 
-    prints::
+       for link in link_expr.search_string(text):
+           # attributes in the <A> tag (like "href" shown here) are
+           # also accessible as named results
+           print(link.link_text, '->', link.href)
 
-        pyparsing -> https://github.com/pyparsing/pyparsing/wiki
+    prints:
+
+    .. testoutput::
+
+       pyparsing -> https://github.com/pyparsing/pyparsing/wiki
     """
     return _makeTags(tag_str, False)
 
@@ -737,69 +791,77 @@ def infix_notation(
 
     Parameters:
 
-    - ``base_expr`` - expression representing the most basic operand to
-      be used in the expression
-    - ``op_list`` - list of tuples, one for each operator precedence level
-      in the expression grammar; each tuple is of the form ``(op_expr,
-      num_operands, right_left_assoc, (optional)parse_action)``, where:
+    :param base_expr: expression representing the most basic operand to
+       be used in the expression
+    :param op_list: list of tuples, one for each operator precedence level
+       in the expression grammar; each tuple is of the form ``(op_expr,
+       num_operands, right_left_assoc, (optional)parse_action)``, where:
 
-      - ``op_expr`` is the pyparsing expression for the operator; may also
-        be a string, which will be converted to a Literal; if ``num_operands``
-        is 3, ``op_expr`` is a tuple of two expressions, for the two
-        operators separating the 3 terms
-      - ``num_operands`` is the number of terms for this operator (must be 1,
-        2, or 3)
-      - ``right_left_assoc`` is the indicator whether the operator is right
-        or left associative, using the pyparsing-defined constants
-        ``OpAssoc.RIGHT`` and ``OpAssoc.LEFT``.
-      - ``parse_action`` is the parse action to be associated with
-        expressions matching this operator expression (the parse action
-        tuple member may be omitted); if the parse action is passed
-        a tuple or list of functions, this is equivalent to calling
-        ``set_parse_action(*fn)``
-        (:class:`ParserElement.set_parse_action`)
-    - ``lpar`` - expression for matching left-parentheses; if passed as a
-      str, then will be parsed as ``Suppress(lpar)``. If lpar is passed as
-      an expression (such as ``Literal('(')``), then it will be kept in
-      the parsed results, and grouped with them. (default= ``Suppress('(')``)
-    - ``rpar`` - expression for matching right-parentheses; if passed as a
-      str, then will be parsed as ``Suppress(rpar)``. If rpar is passed as
-      an expression (such as ``Literal(')')``), then it will be kept in
-      the parsed results, and grouped with them. (default= ``Suppress(')')``)
+       - ``op_expr`` is the pyparsing expression for the operator; may also
+         be a string, which will be converted to a Literal; if ``num_operands``
+         is 3, ``op_expr`` is a tuple of two expressions, for the two
+         operators separating the 3 terms
+       - ``num_operands`` is the number of terms for this operator (must be 1,
+         2, or 3)
+       - ``right_left_assoc`` is the indicator whether the operator is right
+         or left associative, using the pyparsing-defined constants
+         ``OpAssoc.RIGHT`` and ``OpAssoc.LEFT``.
+       - ``parse_action`` is the parse action to be associated with
+         expressions matching this operator expression (the parse action
+         tuple member may be omitted); if the parse action is passed
+         a tuple or list of functions, this is equivalent to calling
+         ``set_parse_action(*fn)``
+         (:class:`ParserElement.set_parse_action`)
 
-    Example::
+    :param lpar: expression for matching left-parentheses; if passed as a
+       str, then will be parsed as ``Suppress(lpar)``. If lpar is passed as
+       an expression (such as ``Literal('(')``), then it will be kept in
+       the parsed results, and grouped with them. (default= ``Suppress('(')``)
+    :param rpar: expression for matching right-parentheses; if passed as a
+       str, then will be parsed as ``Suppress(rpar)``. If rpar is passed as
+       an expression (such as ``Literal(')')``), then it will be kept in
+       the parsed results, and grouped with them. (default= ``Suppress(')')``)
 
-        # simple example of four-function arithmetic with ints and
-        # variable names
-        integer = pyparsing_common.signed_integer
-        varname = pyparsing_common.identifier
+    Example:
 
-        arith_expr = infix_notation(integer | varname,
-            [
-            ('-', 1, OpAssoc.RIGHT),
-            (one_of('* /'), 2, OpAssoc.LEFT),
-            (one_of('+ -'), 2, OpAssoc.LEFT),
-            ])
+    .. testcode::
 
-        arith_expr.run_tests('''
-            5+3*6
-            (5+3)*6
-            -2--11
-            ''', full_dump=False)
+       # simple example of four-function arithmetic with ints and
+       # variable names
+       integer = pyparsing_common.signed_integer
+       varname = pyparsing_common.identifier
 
-    prints::
+       arith_expr = infix_notation(integer | varname,
+           [
+           ('-', 1, OpAssoc.RIGHT),
+           (one_of('* /'), 2, OpAssoc.LEFT),
+           (one_of('+ -'), 2, OpAssoc.LEFT),
+           ])
 
-        5+3*6
-        [[5, '+', [3, '*', 6]]]
+       arith_expr.run_tests('''
+           5+3*6
+           (5+3)*6
+           (5+x)*y
+           -2--11
+           ''', full_dump=False)
 
-        (5+3)*6
-        [[[5, '+', 3], '*', 6]]
+    prints:
 
-        (5+x)*y
-        [[[5, '+', 'x'], '*', 'y']]
+    .. testoutput::
+       :options: +NORMALIZE_WHITESPACE
 
-        -2--11
-        [[['-', 2], '-', ['-', 11]]]
+
+       5+3*6
+       [[5, '+', [3, '*', 6]]]
+
+       (5+3)*6
+       [[[5, '+', 3], '*', 6]]
+
+       (5+x)*y
+       [[[5, '+', 'x'], '*', 'y']]
+
+       -2--11
+       [[['-', 2], '-', ['-', 11]]]
     """
 
     # captive version of FollowedBy that does not do parse actions or capture results names
@@ -922,85 +984,87 @@ def indentedBlock(blockStatementExpr, indentStack, indent=True, backup_stacks=[]
     Helper method for defining space-delimited indentation blocks,
     such as those used to define block statements in Python source code.
 
-    Parameters:
-
-    - ``blockStatementExpr`` - expression defining syntax of statement that
+    :param blockStatementExpr: expression defining syntax of statement that
       is repeated within the indented block
-    - ``indentStack`` - list created by caller to manage indentation stack
+
+    :param indentStack: list created by caller to manage indentation stack
       (multiple ``statementWithIndentedBlock`` expressions within a single
       grammar should share a common ``indentStack``)
-    - ``indent`` - boolean indicating whether block must be indented beyond
+
+    :param indent: boolean indicating whether block must be indented beyond
       the current level; set to ``False`` for block of left-most statements
-      (default= ``True``)
 
     A valid block must contain at least one ``blockStatement``.
 
     (Note that indentedBlock uses internal parse actions which make it
     incompatible with packrat parsing.)
 
-    Example::
+    Example:
 
-        data = '''
-        def A(z):
-          A1
-          B = 100
-          G = A2
-          A2
-          A3
-        B
-        def BB(a,b,c):
-          BB1
-          def BBA():
-            bba1
-            bba2
-            bba3
-        C
-        D
-        def spam(x,y):
-             def eggs(z):
-                 pass
-        '''
+    .. testcode::
 
+       data = '''
+       def A(z):
+         A1
+         B = 100
+         G = A2
+         A2
+         A3
+       B
+       def BB(a,b,c):
+         BB1
+         def BBA():
+           bba1
+           bba2
+           bba3
+       C
+       D
+       def spam(x,y):
+            def eggs(z):
+                pass
+       '''
 
-        indentStack = [1]
-        stmt = Forward()
+       indentStack = [1]
+       stmt = Forward()
 
-        identifier = Word(alphas, alphanums)
-        funcDecl = ("def" + identifier + Group("(" + Opt(delimitedList(identifier)) + ")") + ":")
-        func_body = indentedBlock(stmt, indentStack)
-        funcDef = Group(funcDecl + func_body)
+       identifier = Word(alphas, alphanums)
+       funcDecl = ("def" + identifier + Group("(" + Opt(delimitedList(identifier)) + ")") + ":")
+       func_body = indentedBlock(stmt, indentStack)
+       funcDef = Group(funcDecl + func_body)
 
-        rvalue = Forward()
-        funcCall = Group(identifier + "(" + Opt(delimitedList(rvalue)) + ")")
-        rvalue << (funcCall | identifier | Word(nums))
-        assignment = Group(identifier + "=" + rvalue)
-        stmt << (funcDef | assignment | identifier)
+       rvalue = Forward()
+       funcCall = Group(identifier + "(" + Opt(delimitedList(rvalue)) + ")")
+       rvalue << (funcCall | identifier | Word(nums))
+       assignment = Group(identifier + "=" + rvalue)
+       stmt << (funcDef | assignment | identifier)
 
-        module_body = stmt[1, ...]
+       module_body = stmt[1, ...]
 
-        parseTree = module_body.parseString(data)
-        parseTree.pprint()
+       parseTree = module_body.parseString(data)
+       parseTree.pprint()
 
-    prints::
+    prints:
 
-        [['def',
-          'A',
-          ['(', 'z', ')'],
-          ':',
-          [['A1'], [['B', '=', '100']], [['G', '=', 'A2']], ['A2'], ['A3']]],
-         'B',
-         ['def',
-          'BB',
-          ['(', 'a', 'b', 'c', ')'],
-          ':',
-          [['BB1'], [['def', 'BBA', ['(', ')'], ':', [['bba1'], ['bba2'], ['bba3']]]]]],
-         'C',
-         'D',
-         ['def',
-          'spam',
-          ['(', 'x', 'y', ')'],
-          ':',
-          [[['def', 'eggs', ['(', 'z', ')'], ':', [['pass']]]]]]]
+    .. testoutput::
+
+       [['def',
+         'A',
+         ['(', 'z', ')'],
+         ':',
+         [['A1'], [['B', '=', '100']], [['G', '=', 'A2']], ['A2'], ['A3']]],
+        'B',
+        ['def',
+         'BB',
+         ['(', 'a', 'b', 'c', ')'],
+         ':',
+         [['BB1'], [['def', 'BBA', ['(', ')'], ':', [['bba1'], ['bba2'], ['bba3']]]]]],
+        'C',
+        'D',
+        ['def',
+         'spam',
+         ['(', 'x', 'y', ')'],
+         ':',
+         [[['def', 'eggs', ['(', 'z', ')'], ':', [['pass']]]]]]]
     """
     backup_stacks.append(indentStack[:])
 

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -1,4 +1,5 @@
 # results.py
+
 from __future__ import annotations
 
 import collections
@@ -44,42 +45,48 @@ class ParseResults:
     - by list index (``results[0], results[1]``, etc.)
     - by attribute (``results.<results_name>`` - see :class:`ParserElement.set_results_name`)
 
-    Example::
+    Example:
 
-        integer = Word(nums)
-        date_str = (integer.set_results_name("year") + '/'
-                    + integer.set_results_name("month") + '/'
-                    + integer.set_results_name("day"))
-        # equivalent form:
-        # date_str = (integer("year") + '/'
-        #             + integer("month") + '/'
-        #             + integer("day"))
+    .. testcode::
 
-        # parse_string returns a ParseResults object
-        result = date_str.parse_string("1999/12/31")
+       integer = Word(nums)
+       date_str = (integer.set_results_name("year") + '/'
+                   + integer.set_results_name("month") + '/'
+                   + integer.set_results_name("day"))
+       # equivalent form:
+       # date_str = (integer("year") + '/'
+       #             + integer("month") + '/'
+       #             + integer("day"))
 
-        def test(s, fn=repr):
-            print(f"{s} -> {fn(eval(s))}")
-        test("list(result)")
-        test("result[0]")
-        test("result['month']")
-        test("result.day")
-        test("'month' in result")
-        test("'minutes' in result")
-        test("result.dump()", str)
+       # parse_string returns a ParseResults object
+       result = date_str.parse_string("1999/12/31")
 
-    prints::
+       def test(s, fn=repr):
+           print(f"{s} -> {fn(eval(s))}")
 
-        list(result) -> ['1999', '/', '12', '/', '31']
-        result[0] -> '1999'
-        result['month'] -> '12'
-        result.day -> '31'
-        'month' in result -> True
-        'minutes' in result -> False
-        result.dump() -> ['1999', '/', '12', '/', '31']
-        - day: '31'
-        - month: '12'
-        - year: '1999'
+       test("list(result)")
+       test("result[0]")
+       test("result['month']")
+       test("result.day")
+       test("'month' in result")
+       test("'minutes' in result")
+       test("result.dump()", str)
+
+    prints:
+
+    .. testoutput::
+
+       list(result) -> ['1999', '/', '12', '/', '31']
+       result[0] -> '1999'
+       result['month'] -> '12'
+       result.day -> '31'
+       'month' in result -> True
+       'minutes' in result -> False
+       result.dump() -> ['1999', '/', '12', '/', '31']
+       - day: '31'
+       - month: '12'
+       - year: '1999'
+
     """
 
     _null_values: tuple[Any, ...] = (None, [], ())
@@ -103,38 +110,59 @@ class ParseResults:
     class List(list):
         """
         Simple wrapper class to distinguish parsed list results that should be preserved
-        as actual Python lists, instead of being converted to :class:`ParseResults`::
+        as actual Python lists, instead of being converted to :class:`ParseResults`:
 
-            LBRACK, RBRACK = map(pp.Suppress, "[]")
-            element = pp.Forward()
-            item = ppc.integer
-            element_list = LBRACK + pp.DelimitedList(element) + RBRACK
+        .. testcode::
 
-            # add parse actions to convert from ParseResults to actual Python collection types
-            def as_python_list(t):
-                return pp.ParseResults.List(t.as_list())
-            element_list.add_parse_action(as_python_list)
+           import pyparsing as pp
+           ppc = pp.common
 
-            element <<= item | element_list
+           LBRACK, RBRACK, LPAR, RPAR = pp.Suppress.using_each("[]()")
+           element = pp.Forward()
+           item = ppc.integer
+           item_list = pp.DelimitedList(element)
+           element_list = LBRACK + item_list + RBRACK | LPAR + item_list + RPAR
+           element <<= item | element_list
 
-            element.run_tests('''
-                100
-                [2,3,4]
-                [[2, 1],3,4]
-                [(2, 1),3,4]
-                (2,3,4)
-                ''', post_parse=lambda s, r: (r[0], type(r[0])))
+           # add parse action to convert from ParseResults
+           # to actual Python collection types
+           @element_list.add_parse_action
+           def as_python_list(t):
+               return pp.ParseResults.List(t.as_list())
 
-        prints::
+           element.run_tests('''
+               100
+               [2,3,4]
+               [[2, 1],3,4]
+               [(2, 1),3,4]
+               (2,3,4)
+               ([2, 3], 4)
+               ''', post_parse=lambda s, r: (r[0], type(r[0]))
+           )
 
-            100
-            (100, <class 'int'>)
+        prints:
 
-            [2,3,4]
-            ([2, 3, 4], <class 'list'>)
+        .. testoutput::
+           :options: +NORMALIZE_WHITESPACE
 
-            [[2, 1],3,4]
-            ([[2, 1], 3, 4], <class 'list'>)
+
+           100
+           (100, <class 'int'>)
+
+           [2,3,4]
+           ([2, 3, 4], <class 'list'>)
+
+           [[2, 1],3,4]
+           ([[2, 1], 3, 4], <class 'list'>)
+
+           [(2, 1),3,4]
+           ([[2, 1], 3, 4], <class 'list'>)
+
+           (2,3,4)
+           ([2, 3, 4], <class 'list'>)
+
+           ([2, 3], 4)
+           ([[2, 3], 4], <class 'list'>)
 
         (Used internally by :class:`Group` when `aslist=True`.)
         """
@@ -301,34 +329,40 @@ class ParseResults:
         names. A second default return value argument is supported, just as in
         ``dict.pop()``.
 
-        Example::
+        Example:
 
-            numlist = Word(nums)[...]
-            print(numlist.parse_string("0 123 321")) # -> ['0', '123', '321']
+        .. doctest::
 
-            def remove_first(tokens):
-                tokens.pop(0)
-            numlist.add_parse_action(remove_first)
-            print(numlist.parse_string("0 123 321")) # -> ['123', '321']
+           >>> numlist = Word(nums)[...]
+           >>> print(numlist.parse_string("0 123 321"))
+           ['0', '123', '321']
 
-            label = Word(alphas)
-            patt = label("LABEL") + Word(nums)[1, ...]
-            print(patt.parse_string("AAB 123 321").dump())
+           >>> def remove_first(tokens):
+           ...     tokens.pop(0)
+           ...
+           >>> numlist.add_parse_action(remove_first)
+           [W:(0-9)]...
+           >>> print(numlist.parse_string("0 123 321"))
+           ['123', '321']
 
-            # Use pop() in a parse action to remove named result (note that corresponding value is not
-            # removed from list form of results)
-            def remove_LABEL(tokens):
-                tokens.pop("LABEL")
-                return tokens
-            patt.add_parse_action(remove_LABEL)
-            print(patt.parse_string("AAB 123 321").dump())
+           >>> label = Word(alphas)
+           >>> patt = label("LABEL") + Word(nums)[1, ...]
+           >>> print(patt.parse_string("AAB 123 321").dump())
+           ['AAB', '123', '321']
+           - LABEL: 'AAB'
 
-        prints::
+           >>> # Use pop() in a parse action to remove named result
+           >>> # (note that corresponding value is not
+           >>> # removed from list form of results)
+           >>> def remove_LABEL(tokens):
+           ...     tokens.pop("LABEL")
+           ...     return tokens
+           ...
+           >>> patt.add_parse_action(remove_LABEL)
+           {W:(A-Za-z) {W:(0-9)}...}
+           >>> print(patt.parse_string("AAB 123 321").dump())
+           ['AAB', '123', '321']
 
-            ['AAB', '123', '321']
-            - LABEL: 'AAB'
-
-            ['AAB', '123', '321']
         """
         if not args:
             args = [-1]
@@ -354,15 +388,20 @@ class ParseResults:
 
         Similar to ``dict.get()``.
 
-        Example::
+        Example:
 
-            integer = Word(nums)
-            date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
+        .. doctest::
 
-            result = date_str.parse_string("1999/12/31")
-            print(result.get("year")) # -> '1999'
-            print(result.get("hour", "not specified")) # -> 'not specified'
-            print(result.get("hour")) # -> None
+           >>> integer = Word(nums)
+           >>> date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
+
+           >>> result = date_str.parse_string("1999/12/31")
+           >>> result.get("year")
+           '1999'
+           >>> result.get("hour", "not specified")
+           'not specified'
+           >>> result.get("hour")
+
         """
         if key in self:
             return self[key]
@@ -375,16 +414,24 @@ class ParseResults:
 
         Similar to ``list.insert()``.
 
-        Example::
+        Example:
 
-            numlist = Word(nums)[...]
-            print(numlist.parse_string("0 123 321")) # -> ['0', '123', '321']
+        .. doctest::
 
-            # use a parse action to insert the parse location in the front of the parsed results
-            def insert_locn(locn, tokens):
-                tokens.insert(0, locn)
-            numlist.add_parse_action(insert_locn)
-            print(numlist.parse_string("0 123 321")) # -> [0, '0', '123', '321']
+           >>> numlist = Word(nums)[...]
+           >>> print(numlist.parse_string("0 123 321"))
+           ['0', '123', '321']
+
+           >>> # use a parse action to insert the parse location
+           >>> # in the front of the parsed results
+           >>> def insert_locn(locn, tokens):
+           ...     tokens.insert(0, locn)
+           ...
+           >>> numlist.add_parse_action(insert_locn)
+           [W:(0-9)]...
+           >>> print(numlist.parse_string("0 123 321"))
+           [0, '0', '123', '321']
+
         """
         self._toklist.insert(index, ins_string)
         # fixup indices in token dictionary
@@ -398,16 +445,23 @@ class ParseResults:
         """
         Add single element to end of ``ParseResults`` list of elements.
 
-        Example::
+        Example:
 
-            numlist = Word(nums)[...]
-            print(numlist.parse_string("0 123 321")) # -> ['0', '123', '321']
+        .. doctest::
 
-            # use a parse action to compute the sum of the parsed integers, and add it to the end
-            def append_sum(tokens):
-                tokens.append(sum(map(int, tokens)))
-            numlist.add_parse_action(append_sum)
-            print(numlist.parse_string("0 123 321")) # -> ['0', '123', '321', 444]
+           >>> numlist = Word(nums)[...]
+           >>> print(numlist.parse_string("0 123 321"))
+           ['0', '123', '321']
+
+           >>> # use a parse action to compute the sum of the parsed integers,
+           >>> # and add it to the end
+           >>> def append_sum(tokens):
+           ...     tokens.append(sum(map(int, tokens)))
+           ...
+           >>> numlist.add_parse_action(append_sum)
+           [W:(0-9)]...
+           >>> print(numlist.parse_string("0 123 321"))
+           ['0', '123', '321', 444]
         """
         self._toklist.append(item)
 
@@ -415,16 +469,26 @@ class ParseResults:
         """
         Add sequence of elements to end of ``ParseResults`` list of elements.
 
-        Example::
+        Example:
 
-            patt = Word(alphas)[1, ...]
+        .. testcode::
 
-            # use a parse action to append the reverse of the matched strings, to make a palindrome
-            def make_palindrome(tokens):
-                tokens.extend(reversed([t[::-1] for t in tokens]))
-                return ''.join(tokens)
-            patt.add_parse_action(make_palindrome)
-            print(patt.parse_string("lskdj sdlkjf lksd")) # -> 'lskdjsdlkjflksddsklfjkldsjdksl'
+           patt = Word(alphas)[1, ...]
+
+           # use a parse action to append the reverse of the matched strings,
+           # to make a palindrome
+           def make_palindrome(tokens):
+               tokens.extend(reversed([t[::-1] for t in tokens]))
+               return ''.join(tokens)
+
+           patt.add_parse_action(make_palindrome)
+           print(patt.parse_string("lskdj sdlkjf lksd"))
+
+        prints:
+
+        .. testoutput::
+
+           ['lskdjsdlkjflksddsklfjkldsjdksl']
         """
         if isinstance(itemseq, ParseResults):
             self.__iadd__(itemseq)
@@ -512,17 +576,28 @@ class ParseResults:
         Returns the parse results as a nested list of matching tokens, all converted to strings.
         If flatten is True, all the nesting levels in the returned list are collapsed.
 
-        Example::
+        Example:
 
-            patt = Word(alphas)[1, ...]
-            result = patt.parse_string("sldkj lsdkj sldkj")
-            # even though the result prints in string-like form, it is actually a pyparsing ParseResults
-            print(type(result), result) # -> <class 'pyparsing.ParseResults'> ['sldkj', 'lsdkj', 'sldkj']
+        .. doctest::
 
-            # Use as_list() to create an actual list
-            result_list = result.as_list()
-            print(type(result_list), result_list) # -> <class 'list'> ['sldkj', 'lsdkj', 'sldkj']
+           >>> patt = Word(alphas)[1, ...]
+           >>> result = patt.parse_string("sldkj lsdkj sldkj")
+           >>> # even though the result prints in string-like form,
+           >>> # it is actually a pyparsing ParseResults
+           >>> type(result)
+           <class 'pyparsing.results.ParseResults'>
+           >>> print(result)
+           ['sldkj', 'lsdkj', 'sldkj']
 
+        .. doctest::
+
+           >>> # Use as_list() to create an actual list
+           >>> result_list = result.as_list()
+           >>> type(result_list)
+           <class 'list'>
+           >>> print(result_list)
+           ['sldkj', 'lsdkj', 'sldkj']
+        
         .. versionchanged:: 3.2.0
            New ``flatten`` argument.
         """
@@ -548,21 +623,33 @@ class ParseResults:
         """
         Returns the named parse results as a nested dictionary.
 
-        Example::
+        Example:
 
-            integer = Word(nums)
-            date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
+        .. doctest::
 
-            result = date_str.parse_string('12/31/1999')
-            print(type(result), repr(result)) # -> <class 'pyparsing.ParseResults'> (['12', '/', '31', '/', '1999'], {'day': [('1999', 4)], 'year': [('12', 0)], 'month': [('31', 2)]})
+           >>> integer = pp.Word(pp.nums)
+           >>> date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
 
-            result_dict = result.as_dict()
-            print(type(result_dict), repr(result_dict)) # -> <class 'dict'> {'day': '1999', 'year': '12', 'month': '31'}
+           >>> result = date_str.parse_string('1999/12/31')
+           >>> type(result)
+           <class 'pyparsing.results.ParseResults'>
+           >>> result
+           ParseResults(['1999', '/', '12', '/', '31'], {'year': '1999', 'month': '12', 'day': '31'})
 
-            # even though a ParseResults supports dict-like access, sometime you just need to have a dict
-            import json
-            print(json.dumps(result)) # -> Exception: TypeError: ... is not JSON serializable
-            print(json.dumps(result.as_dict())) # -> {"month": "31", "day": "1999", "year": "12"}
+           >>> result_dict = result.as_dict()
+           >>> type(result_dict)
+           <class 'dict'>
+           >>> result_dict
+           {'year': '1999', 'month': '12', 'day': '31'}
+
+           >>> # even though a ParseResults supports dict-like access,
+           >>> # sometime you just need to have a dict
+           >>> import json
+           >>> print(json.dumps(result))
+           Traceback (most recent call last):
+           TypeError: Object of type ParseResults is not JSON serializable
+           >>> print(json.dumps(result.as_dict()))
+           {"year": "1999", "month": "12", "day": "31"}
         """
 
         def to_item(obj):
@@ -615,25 +702,30 @@ class ParseResults:
         Returns the results name for this token expression. Useful when several
         different expressions might match at a particular location.
 
-        Example::
+        Example:
 
-            integer = Word(nums)
-            ssn_expr = Regex(r"\d\d\d-\d\d-\d\d\d\d")
-            house_number_expr = Suppress('#') + Word(nums, alphanums)
-            user_data = (Group(house_number_expr)("house_number")
-                        | Group(ssn_expr)("ssn")
-                        | Group(integer)("age"))
-            user_info = user_data[1, ...]
+        .. testcode::
 
-            result = user_info.parse_string("22 111-22-3333 #221B")
-            for item in result:
-                print(item.get_name(), ':', item[0])
+           integer = Word(nums)
+           ssn_expr = Regex(r"\d\d\d-\d\d-\d\d\d\d")
+           house_number_expr = Suppress('#') + Word(nums, alphanums)
+           user_data = (Group(house_number_expr)("house_number")
+                       | Group(ssn_expr)("ssn")
+                       | Group(integer)("age"))
+           user_info = user_data[1, ...]
 
-        prints::
+           result = user_info.parse_string("22 111-22-3333 #221B")
+           for item in result:
+               print(item.get_name(), ':', item[0])
 
-            age : 22
-            ssn : 111-22-3333
-            house_number : 221B
+        prints:
+
+        .. testoutput::
+
+           age : 22
+           ssn : 111-22-3333
+           house_number : 221B
+
         """
         if self._name:
             return self._name
@@ -664,20 +756,24 @@ class ParseResults:
         a :class:`ParseResults`. Accepts an optional ``indent`` argument so
         that this string can be embedded in a nested display of other data.
 
-        Example::
+        Example:
 
-            integer = Word(nums)
-            date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
+        .. testcode::
 
-            result = date_str.parse_string('1999/12/31')
-            print(result.dump())
+           integer = Word(nums)
+           date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
 
-        prints::
+           result = date_str.parse_string('1999/12/31')
+           print(result.dump())
 
-            ['1999', '/', '12', '/', '31']
-            - day: '31'
-            - month: '12'
-            - year: '1999'
+        prints:
+
+        .. testoutput::
+
+           ['1999', '/', '12', '/', '31']
+           - day: '31'
+           - month: '12'
+           - year: '1999'
         """
         out = []
         NL = "\n"
@@ -739,23 +835,27 @@ class ParseResults:
         Accepts additional positional or keyword args as defined for
         `pprint.pprint <https://docs.python.org/3/library/pprint.html#pprint.pprint>`_ .
 
-        Example::
+        Example:
 
-            ident = Word(alphas, alphanums)
-            num = Word(nums)
-            func = Forward()
-            term = ident | num | Group('(' + func + ')')
-            func <<= ident + Group(Optional(DelimitedList(term)))
-            result = func.parse_string("fna a,b,(fnb c,d,200),100")
-            result.pprint(width=40)
+        .. testcode::
 
-        prints::
+           ident = Word(alphas, alphanums)
+           num = Word(nums)
+           func = Forward()
+           term = ident | num | Group('(' + func + ')')
+           func <<= ident + Group(Optional(DelimitedList(term)))
+           result = func.parse_string("fna a,b,(fnb c,d,200),100")
+           result.pprint(width=40)
 
-            ['fna',
-             ['a',
-              'b',
-              ['(', 'fnb', ['c', 'd', '200'], ')'],
-              '100']]
+        prints:
+
+        .. testoutput::
+
+           ['fna',
+            ['a',
+             'b',
+             ['(', 'fnb', ['c', 'd', '200'], ')'],
+             '100']]
         """
         pprint.pprint(self.as_list(), *args, **kwargs)
 

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -909,17 +909,21 @@ class ParseResults:
             ret = cls([ret], name=name)
         return ret
 
-    # XXX: These docstrings don't show up in the documentation
-    #      (asList.__doc__ is the same as as_list.__doc__)
     asList = as_list
-    """.. deprecated:: 3.0.0
-          use :class:`as_list`"""
+    """
+    .. deprecated:: 3.0.0
+       use :class:`as_list`
+    """
     asDict = as_dict
-    """.. deprecated:: 3.0.0
-          use :class:`as_dict`"""
+    """
+    .. deprecated:: 3.0.0
+       use :class:`as_dict`
+    """
     getName = get_name
-    """.. deprecated:: 3.0.0
-          use :class:`get_name`"""
+    """
+    .. deprecated:: 3.0.0
+       use :class:`get_name`
+    """
 
 
 MutableMapping.register(ParseResults)

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -467,7 +467,7 @@ class ParseResults:
 
     def extend(self, itemseq):
         """
-        Add sequence of elements to end of ``ParseResults`` list of elements.
+        Add sequence of elements to end of :class:`ParseResults` list of elements.
 
         Example:
 
@@ -574,7 +574,7 @@ class ParseResults:
     def as_list(self, *, flatten: bool = False) -> list:
         """
         Returns the parse results as a nested list of matching tokens, all converted to strings.
-        If flatten is True, all the nesting levels in the returned list are collapsed.
+        If ``flatten`` is True, all the nesting levels in the returned list are collapsed.
 
         Example:
 
@@ -662,10 +662,10 @@ class ParseResults:
 
     def copy(self) -> ParseResults:
         """
-        Returns a new shallow copy of a :class:`ParseResults` object. `ParseResults`
-        items contained within the source are shared with the copy. Use
-        :class:`ParseResults.deepcopy()` to create a copy with its own separate
-        content values.
+        Returns a new shallow copy of a :class:`ParseResults` object.
+        :class:`ParseResults` items contained within the source are
+        shared with the copy. Use :meth:`ParseResults.deepcopy` to
+        create a copy with its own separate content values.
         """
         ret = ParseResults(self._toklist)
         ret._tokdict = self._tokdict.copy()
@@ -699,8 +699,10 @@ class ParseResults:
 
     def get_name(self) -> str | None:
         r"""
-        Returns the results name for this token expression. Useful when several
-        different expressions might match at a particular location.
+        Returns the results name for this token expression.
+
+        Useful when several different expressions might match
+        at a particular location.
 
         Example:
 
@@ -885,9 +887,9 @@ class ParseResults:
     @classmethod
     def from_dict(cls, other, name=None) -> ParseResults:
         """
-        Helper classmethod to construct a ``ParseResults`` from a ``dict``, preserving the
+        Helper classmethod to construct a :class:`ParseResults` from a ``dict``, preserving the
         name-value relations as results names. If an optional ``name`` argument is
-        given, a nested ``ParseResults`` will be returned.
+        given, a nested :class:`ParseResults` will be returned.
         """
 
         def is_iterable(obj):
@@ -912,17 +914,17 @@ class ParseResults:
     asList = as_list
     """
     .. deprecated:: 3.0.0
-       use :class:`as_list`
+       use :meth:`as_list`
     """
     asDict = as_dict
     """
     .. deprecated:: 3.0.0
-       use :class:`as_dict`
+       use :meth:`as_dict`
     """
     getName = get_name
     """
     .. deprecated:: 3.0.0
-       use :class:`get_name`
+       use :meth:`get_name`
     """
 
 

--- a/pyparsing/testing.py
+++ b/pyparsing/testing.py
@@ -24,24 +24,37 @@ class pyparsing_test:
         Context manager to be used when writing unit tests that modify pyparsing config values:
         - packrat parsing
         - bounded recursion parsing
-        - default whitespace characters.
+        - default whitespace characters
         - default keyword characters
         - literal string auto-conversion class
-        - __diag__ settings
+        - ``__diag__`` settings
 
-        Example::
+        Example:
 
-            with reset_pyparsing_context():
-                # test that literals used to construct a grammar are automatically suppressed
-                ParserElement.inlineLiteralsUsing(Suppress)
+        .. testcode::
 
-                term = Word(alphas) | Word(nums)
-                group = Group('(' + term[...] + ')')
+            ppt = pyparsing.pyparsing_test
 
-                # assert that the '()' characters are not included in the parsed tokens
-                self.assertParseAndCheckList(group, "(abc 123 def)", ['abc', '123', 'def'])
+            class MyTestClass(ppt.TestParseResultsAsserts):
+                def test_literal(self):
+                    with ppt.reset_pyparsing_context():
+                        # test that literals used to construct
+                        # a grammar are automatically suppressed
+                        ParserElement.inline_literals_using(Suppress)
 
-            # after exiting context manager, literals are converted to Literal expressions again
+                        term = Word(alphas) | Word(nums)
+                        group = Group('(' + term[...] + ')')
+
+                        # assert that the '()' characters
+                        # are not included in the parsed tokens
+                        self.assertParseAndCheckList(
+                            group,
+                            "(abc 123 def)",
+                            ['abc', '123', 'def']
+                        )
+
+                    # after exiting context manager, literals
+                    # are converted to Literal expressions again
         """
 
         def __init__(self):
@@ -145,7 +158,7 @@ class pyparsing_test:
         ):
             """
             Convenience wrapper assert to test a parser element and input string, and assert that
-            the resulting ``ParseResults.asList()`` is equal to the ``expected_list``.
+            the resulting :meth:`ParseResults.as_list` is equal to the ``expected_list``.
             """
             result = expr.parse_string(test_string, parse_all=True)
             if verbose:
@@ -159,7 +172,7 @@ class pyparsing_test:
         ):
             """
             Convenience wrapper assert to test a parser element and input string, and assert that
-            the resulting ``ParseResults.asDict()`` is equal to the ``expected_dict``.
+            the resulting :meth:`ParseResults.as_dict` is equal to the ``expected_dict``.
             """
             result = expr.parse_string(test_string, parseAll=True)
             if verbose:
@@ -172,13 +185,20 @@ class pyparsing_test:
             self, run_tests_report, expected_parse_results=None, msg=None
         ):
             """
-            Unit test assertion to evaluate output of ``ParserElement.runTests()``. If a list of
-            list-dict tuples is given as the ``expected_parse_results`` argument, then these are zipped
-            with the report tuples returned by ``runTests`` and evaluated using ``assertParseResultsEquals``.
-            Finally, asserts that the overall ``runTests()`` success value is ``True``.
+            Unit test assertion to evaluate output of
+            :meth:`~ParserElement.run_tests`.
 
-            :param run_tests_report: tuple(bool, [tuple(str, ParseResults or Exception)]) returned from runTests
-            :param expected_parse_results (optional): [tuple(str, list, dict, Exception)]
+            If a list of list-dict tuples is given as the
+            ``expected_parse_results`` argument, then these are zipped
+            with the report tuples returned by ``run_tests()``
+            and evaluated using :meth:`assertParseResultsEquals`.
+            Finally, asserts that the overall
+            `:meth:~ParserElement.run_tests` success value is ``True``.
+
+            :param run_tests_report: the return value from :meth:`ParserElement.run_tests`
+            :type run_tests_report: tuple[bool, list[tuple[str, ParseResults | Exception]]]
+            :param expected_parse_results: (optional)
+            :type expected_parse_results: list[tuple[str | list | dict | Exception, ...]]
             """
             run_test_success, run_test_results = run_tests_report
 
@@ -266,23 +286,26 @@ class pyparsing_test:
         (Line and column numbers are 1-based by default - if debugging a parse action,
         pass base_1=False, to correspond to the loc value passed to the parse action.)
 
-        :param s: tuple(bool, str - string to be printed with line and column numbers
-        :param start_line: int - (optional) starting line number in s to print (default=1)
-        :param end_line: int - (optional) ending line number in s to print (default=len(s))
-        :param expand_tabs: bool - (optional) expand tabs to spaces, to match the pyparsing default
-        :param eol_mark: str - (optional) string to mark the end of lines, helps visualize trailing spaces (default="|")
-        :param mark_spaces: str - (optional) special character to display in place of spaces
-        :param mark_control: str - (optional) convert non-printing control characters to a placeholding
-                                 character; valid values:
-                                 - "unicode" - replaces control chars with Unicode symbols, such as "␍" and "␊"
-                                 - any single character string - replace control characters with given string
-                                 - None (default) - string is displayed as-is
-        :param indent: str | int - (optional) string to indent with line and column numbers; if an int
-                                   is passed, converted to " " * indent
-        :param base_1: bool - (optional) whether to label string using base 1; if False, string will be
-                              labeled based at 0 (default=True)
+        :param s: string to be printed with line and column numbers
+        :param start_line: starting line number in s to print (default=1)
+        :param end_line: ending line number in s to print (default=len(s))
+        :param expand_tabs: expand tabs to spaces, to match the pyparsing default
+        :param eol_mark: string to mark the end of lines, helps visualize trailing spaces
+        :param mark_spaces: special character to display in place of spaces
+        :param mark_control: convert non-printing control characters to a placeholding
+                             character; valid values:
+                                 
+                             - ``"unicode"`` - replaces control chars with Unicode symbols, such as "␍" and "␊"
+                             - any single character string - replace control characters with given string
+                             - ``None`` (default) - string is displayed as-is
 
-        :return: str - input string with leading line numbers and column number headers
+
+        :param indent: string to indent with line and column numbers; if an int
+                       is passed, converted to ``" " * indent``
+        :param base_1: whether to label string using base 1; if False, string will be
+                       labeled based at 0
+
+        :returns: input string with leading line numbers and column number headers
 
         .. versionchanged:: 3.2.0
            New ``indent`` and ``base_1`` arguments.

--- a/pyparsing/util.py
+++ b/pyparsing/util.py
@@ -45,7 +45,7 @@ def col(loc: int, strg: str) -> int:
 
     Note: the default parsing behavior is to expand tabs in the input string
     before starting the parsing process.  See
-    :class:`ParserElement.parse_string` for more
+    :meth:`ParserElement.parse_string` for more
     information on parsing strings containing ``<TAB>`` s, and suggested
     methods to maintain a consistent view of the parsed string, the parse
     location, and line and column positions within the parsed string.
@@ -60,7 +60,7 @@ def lineno(loc: int, strg: str) -> int:
     The first line is number 1.
 
     Note - the default parsing behavior is to expand tabs in the input string
-    before starting the parsing process.  See :class:`ParserElement.parse_string`
+    before starting the parsing process.  See :meth:`ParserElement.parse_string`
     for more information on parsing strings containing ``<TAB>`` s, and
     suggested methods to maintain a consistent view of the parsed string, the
     parse location, and line and column positions within the parsed string.
@@ -186,12 +186,24 @@ class _GroupConsecutive:
     """
     Used as a callable `key` for itertools.groupby to group
     characters that are consecutive:
-        itertools.groupby("abcdejkmpqrs", key=IsConsecutive())
-        yields:
-            (0, iter(['a', 'b', 'c', 'd', 'e']))
-            (1, iter(['j', 'k']))
-            (2, iter(['m']))
-            (3, iter(['p', 'q', 'r', 's']))
+    
+    .. testcode::
+
+       from itertools import groupby
+       from pyparsing.util import _GroupConsecutive
+
+       grouped = groupby("abcdejkmpqrs", key=_GroupConsecutive())
+       for index, group in grouped:
+           print(tuple([index, list(group)]))
+
+    prints:
+
+    .. testoutput::
+
+       (0, ['a', 'b', 'c', 'd', 'e'])
+       (1, ['j', 'k'])
+       (2, ['m'])
+       (3, ['p', 'q', 'r', 's'])
     """
 
     def __init__(self) -> None:
@@ -214,21 +226,28 @@ def _collapse_string_to_ranges(
     Take a string or list of single-character strings, and return
     a string of the consecutive characters in that string collapsed
     into groups, as might be used in a regular expression '[a-z]'
-    character set:
+    character set::
+
         'a' -> 'a' -> '[a]'
         'bc' -> 'bc' -> '[bc]'
         'defgh' -> 'd-h' -> '[d-h]'
         'fdgeh' -> 'd-h' -> '[d-h]'
         'jklnpqrtu' -> 'j-lnp-rtu' -> '[j-lnp-rtu]'
-    Duplicates get collapsed out:
+
+    Duplicates get collapsed out::
+
         'aaa' -> 'a' -> '[a]'
         'bcbccb' -> 'bc' -> '[bc]'
         'defghhgf' -> 'd-h' -> '[d-h]'
         'jklnpqrjjjtu' -> 'j-lnp-rtu' -> '[j-lnp-rtu]'
-    Spaces are preserved:
+
+    Spaces are preserved::
+
         'ab c' -> ' a-c' -> '[ a-c]'
+
     Characters that are significant when defining regex ranges
-    get escaped:
+    get escaped::
+
         'acde[]-' -> r'\-\[\]ac-e' -> r'[\-\[\]ac-e]'
     """
 


### PR DESCRIPTION
This PR does a _lot_. The broad strokes:

1. Convert all documentation examples to [doctests](https://docs.python.org/3/library/doctest.html#module-doctest) which can be tested for syntax issues and correct output
2. Add comprehensive documentation on writing doctests to the online docs (new chapter "Writing doctest examples")
3. Restore the Sphinx "Alabaster" theme, but with a (classic-style) local table-of-contents for the API documentation

Not done, yet:

1. Add any Spinx `make doctest` runs to CI or ReadTheDocs configuration.
2. Fix the one failing doctest (details at https://github.com/pyparsing/pyparsing/issues/608#issuecomment-3058546453)