### PR TITLE
Update license metadata to follow PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.12,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyparsing"
 authors = [{name = "Paul McGuire", email = "ptmcg.gm+pyparsing@gmail.com"}]
 readme = "README.rst"
-license = { text = "MIT License" }
+license = "MIT"
+license-files = ["LICENSE"]
 dynamic = ["version", "description"]
 requires-python = ">=3.9"
 classifiers = [


### PR DESCRIPTION
Flit-core added support for PEP 639 in v3.12. Flit automatically detects common license files, so it was already included. However, just to be sure, I also added `license-files` to make it explicit.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

Fixes #626