### PR TITLE
Fix as_dict() returning [] instead of {} for empty Dict results

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -6627,6 +6627,11 @@ class Dict(TokenConverter):
                 else:
                     tokenlist[ikey] = _ParseResultsWithOffset(dictvalue[0], i)
 
+        # Mark the tokenlist so that as_dict() knows to serialize an empty
+        # result as {} rather than [], preserving dict semantics even when
+        # there are no matched entries.
+        tokenlist._is_dict_context = True
+
         if self._asPythonDict:
             return [tokenlist.as_dict()] if self.resultsName else tokenlist.as_dict()
 

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -105,6 +105,7 @@ class ParseResults:
         "_modal",
         "_toklist",
         "_tokdict",
+        "_is_dict_context",
     )
 
     class List(list):
@@ -185,6 +186,7 @@ class ParseResults:
         self._name = None
         self._parent = None
         self._all_names = set()
+        self._is_dict_context = False
 
         if toklist is None:
             self._toklist = []
@@ -659,7 +661,9 @@ class ParseResults:
 
         def to_item(obj):
             if isinstance(obj, ParseResults):
-                return obj.as_dict() if obj.haskeys() else [to_item(v) for v in obj]
+                if obj.haskeys() or obj._is_dict_context:
+                    return obj.as_dict()
+                return [to_item(v) for v in obj]
             else:
                 return obj
 
@@ -679,6 +683,7 @@ class ParseResults:
         ret._all_names = {*self._all_names}
         ret._name = self._name
         ret._modal = self._modal
+        ret._is_dict_context = self._is_dict_context
         return ret
 
     def deepcopy(self) -> ParseResults:
@@ -884,6 +889,7 @@ class ParseResults:
         self._toklist, (self._tokdict, par, inAccumNames, self._name) = state
         self._all_names = set(inAccumNames)
         self._parent = None
+        self._is_dict_context = False
 
     def __getnewargs__(self):
         return self._toklist, self._name


### PR DESCRIPTION
## Problem (fixes #632)

When a named result wraps an empty `Dict(ZeroOrMore(...))` expression, `as_dict()` serializes the inner empty `ParseResults` as `[]` instead of `{}`.

```python
import pyparsing as pp

parser1 = pp.Dict(pp.ZeroOrMore(pp.Group(pp.Word(pp.alphas) + pp.Word(pp.alphas))))
parser2 = parser1.copy()('fubar')

parser1.parse_string('foo bar').as_dict()  # {'foo': 'bar'}  ✓
parser2.parse_string('foo bar').as_dict()  # {'fubar': {'foo': 'bar'}}  ✓

parser1.parse_string('').as_dict()  # {}  ✓
parser2.parse_string('').as_dict()  # {'fubar': []}  ✗  should be {'fubar': {}}
```

## Root Cause

The `to_item()` helper inside `as_dict()` uses `obj.haskeys()` to decide whether to serialize a nested `ParseResults` as a dict or a list. For an **empty** `Dict` result, `_tokdict` is empty (no entries were matched), so `haskeys()` returns `False`, causing the list path to be taken and returning `[]`.

## Fix

Add a lightweight `_is_dict_context: bool` flag to `ParseResults` (default `False`). `Dict.postParse` sets this flag to `True` on every tokenlist it processes — including empty ones. `to_item()` then checks `obj.haskeys() or obj._is_dict_context` so that empty dict contexts serialize as `{}`.

This preserves the existing behaviour for all other empty results (e.g. `ZeroOrMore(val)("values")` returning `[]` when empty), since those do not go through `Dict.postParse`.

## Tests

All 1977 existing tests pass. Verified manual reproduction from the issue is fixed.

Made with [Cursor](https://cursor.com)