### PR TITLE
Fix Located capturing leading whitespace in its location (#621)

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         dry-run: false
         language: python
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,14 @@ Version 3.3.3 - in development
   `leave_whitespace(recursive=True)`. Issue #633, reported by Ahmed Mohamed Abdelaal,
   PR submitted by fcardosojr18 et AI.
 
+- Fixed `Located` reporting a `locn_start` that included leading whitespace when the
+  wrapped expression delegates whitespace skipping to its sub-expressions (such as
+  `MatchFirst` or `And`, whose `callPreparse` is `False`). `Located` now skips the
+  leading whitespace that the wrapped expression would skip before recording the start
+  location, so the located span no longer captures preceding whitespace. Expressions
+  modified with `leave_whitespace()` still keep their leading whitespace as before.
+  Issue #621, reported by MeanSquaredError.
+
 - Update type checking to use `mypy 1.20.0`.
 
 - 5-8% performance boost optimizing `ParseResults.copy()`. Inspired by similar changes

--- a/CHANGES
+++ b/CHANGES
@@ -34,11 +34,9 @@ Version 3.3.3 - in development
   PR submitted by fcardosojr18 et AI.
 
 - Fixed `Located` reporting a `locn_start` that included leading whitespace when the
-  wrapped expression delegates whitespace skipping to its sub-expressions (such as
-  `MatchFirst` or `And`, whose `callPreparse` is `False`). `Located` now skips the
-  leading whitespace that the wrapped expression would skip before recording the start
-  location, so the located span no longer captures preceding whitespace. Expressions
-  modified with `leave_whitespace()` still keep their leading whitespace as before.
+  wrapped expression delegates whitespace skipping to sub-expressions (such as
+  `MatchFirst` or `And`). The leading whitespace is now skipped before the start
+  location is recorded, while `leave_whitespace()` expressions keep their whitespace.
   Issue #621, reported by MeanSquaredError.
 
 - Update type checking to use `mypy 1.20.0`.

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -5583,7 +5583,14 @@ class Located(ParseElementEnhance):
     """
 
     def parseImpl(self, instring, loc, do_actions=True) -> ParseImplReturnType:
-        start = loc
+        # skip any leading whitespace that the wrapped expression would skip,
+        # so that locn_start marks the real start of the match and not the
+        # preceding whitespace. Located adopts callPreparse from its wrapped
+        # expression, so when that expression delegates whitespace skipping to
+        # sub-expressions (e.g. And/MatchFirst, whose callPreparse is False),
+        # Located does not pre-parse it and start would otherwise land on the
+        # leading whitespace (issue #621).
+        start = self.expr.preParse(instring, loc)
         loc, tokens = self.expr._parse(instring, start, do_actions, callPreParse=False)
         ret_tokens = ParseResults([start, tokens, loc])
         ret_tokens["locn_start"] = start

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -5583,13 +5583,10 @@ class Located(ParseElementEnhance):
     """
 
     def parseImpl(self, instring, loc, do_actions=True) -> ParseImplReturnType:
-        # skip any leading whitespace that the wrapped expression would skip,
-        # so that locn_start marks the real start of the match and not the
-        # preceding whitespace. Located adopts callPreparse from its wrapped
-        # expression, so when that expression delegates whitespace skipping to
-        # sub-expressions (e.g. And/MatchFirst, whose callPreparse is False),
-        # Located does not pre-parse it and start would otherwise land on the
-        # leading whitespace (issue #621).
+        # skip leading whitespace before capturing the start location, so
+        # locn_start marks the start of the match and not preceding whitespace,
+        # even when the wrapped expression delegates whitespace skipping to its
+        # sub-expressions (e.g. And/MatchFirst). Issue #621.
         start = self.expr.preParse(instring, loc)
         loc, tokens = self.expr._parse(instring, start, do_actions, callPreParse=False)
         ret_tokens = ParseResults([start, tokens, loc])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6571,18 +6571,16 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             print(pp_match.value)
 
     def testLocatedExprLeadingWhitespace(self):
-        # Located must mark the start of the actual match and skip any leading
-        # whitespace the wrapped expression would skip - even when that
-        # expression delegates whitespace skipping to its sub-expressions, such
-        # as MatchFirst or And (whose callPreparse is False). Issue #621.
+        # Located should mark the start of the match, not leading whitespace the
+        # wrapped expression skips - including when whitespace skipping is
+        # delegated to sub-expressions (MatchFirst, And). Issue #621.
         abc = pp.Keyword("abc")
 
-        # a single token already reported the correct location...
+        # a single token already reported the correct location
         single = pp.Located(abc).parse_string("   abc")
         self.assertParseResultsEquals(single, [3, ["abc"], 6])
 
-        # ...but a MatchFirst used to capture the leading whitespace too,
-        # reporting locn_start=0 and a "   abc" span instead of "abc"
+        # a MatchFirst used to report locn_start=0, a "   abc" span
         match_first = pp.Located(abc | abc).parse_string("   abc")
         self.assertParseResultsEquals(match_first, [3, ["abc"], 6])
         self.assertEqual(
@@ -6591,7 +6589,7 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             "Located(MatchFirst) included leading whitespace in its location",
         )
 
-        # an And (sequence) likewise delegates whitespace skipping
+        # an And likewise delegates whitespace skipping
         sample = "   ID PARI12345678"
         seq = pp.Located(pp.Literal("ID") + pp.Word(pp.alphanums)).parse_string(sample)
         self.assertEqual(
@@ -6600,8 +6598,7 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             "Located(And) included leading whitespace in its location",
         )
 
-        # an expression that explicitly leaves whitespace must keep it, so the
-        # reported start should remain at the leading whitespace
+        # leave_whitespace() must keep the leading whitespace
         leave_ws = pp.Located(pp.Word(" abc").leave_whitespace()).parse_string("   abc")
         self.assertEqual(
             0,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6570,6 +6570,45 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             print(re_match)
             print(pp_match.value)
 
+    def testLocatedExprLeadingWhitespace(self):
+        # Located must mark the start of the actual match and skip any leading
+        # whitespace the wrapped expression would skip - even when that
+        # expression delegates whitespace skipping to its sub-expressions, such
+        # as MatchFirst or And (whose callPreparse is False). Issue #621.
+        abc = pp.Keyword("abc")
+
+        # a single token already reported the correct location...
+        single = pp.Located(abc).parse_string("   abc")
+        self.assertParseResultsEquals(single, [3, ["abc"], 6])
+
+        # ...but a MatchFirst used to capture the leading whitespace too,
+        # reporting locn_start=0 and a "   abc" span instead of "abc"
+        match_first = pp.Located(abc | abc).parse_string("   abc")
+        self.assertParseResultsEquals(match_first, [3, ["abc"], 6])
+        self.assertEqual(
+            "abc",
+            "   abc"[match_first.locn_start : match_first.locn_end],
+            "Located(MatchFirst) included leading whitespace in its location",
+        )
+
+        # an And (sequence) likewise delegates whitespace skipping
+        sample = "   ID PARI12345678"
+        seq = pp.Located(pp.Literal("ID") + pp.Word(pp.alphanums)).parse_string(sample)
+        self.assertEqual(
+            "ID PARI12345678",
+            sample[seq.locn_start : seq.locn_end],
+            "Located(And) included leading whitespace in its location",
+        )
+
+        # an expression that explicitly leaves whitespace must keep it, so the
+        # reported start should remain at the leading whitespace
+        leave_ws = pp.Located(pp.Word(" abc").leave_whitespace()).parse_string("   abc")
+        self.assertEqual(
+            0,
+            leave_ws.locn_start,
+            "Located should not skip whitespace for a leave_whitespace expression",
+        )
+
     def testPop(self):
         source = "AAA 123 456 789 234"
         patt = pp.Word(pp.alphas)("name") + pp.Word(pp.nums) * (1,)


### PR DESCRIPTION
## Summary

Fixes #621.

`Located` decorates a match with its start/end location (`locn_start`, `locn_end`). When the wrapped expression delegates whitespace skipping to its sub-expressions — e.g. a `MatchFirst` (`a | b`) or `And` (`a + b`), whose `callPreparse` is `False` — `Located` adopts that `callPreparse=False` (in `ParseElementEnhance.__init__`) and so does **not** pre-parse the input itself. As a result `Located.parseImpl` captured `start = loc` while `loc` still pointed at the leading whitespace, and `locn_start` (and the located span) wrongly included that whitespace.

### Reproducer (from the issue)

```python
import pyparsing as pp
abc = pp.Keyword("abc")

# single token - already correct
pp.Located(abc).parse_string("   abc")        # [3, ['abc'], 6]

# MatchFirst - returned [0, ['abc'], 6] (span "   abc") before this PR
pp.Located(abc | abc).parse_string("   abc")   # now [3, ['abc'], 6]
```

This matches the diagnosis in the issue thread: *"Located is recording the start position before the inner expression applies whitespace skipping."*

## Fix

In `Located.parseImpl`, capture `start` **after** the wrapped expression's own `preParse` (`start = self.expr.preParse(instring, loc)`) instead of using the raw incoming `loc`. `preParse` honors the wrapped expression's whitespace settings, so:

- expressions that skip whitespace (the common case) now report the real start of the match, and
- expressions modified with `leave_whitespace()` still keep their leading whitespace (their `preParse` is a no-op, so `start` is unchanged).

The subsequent `self.expr._parse(..., callPreParse=False)` call is unchanged.

## Testing

- New regression test `testLocatedExprLeadingWhitespace` covering a single token, `MatchFirst`, `And`, and a `leave_whitespace()` expression. It fails on `master` (`locn_start == 0`) and passes with the fix, across all parametrized parsing configurations (packrat / left-recursion / etc.).
- Full unit suite passes: `tests/test_unit.py` (1832 passed, 6 skipped), plus `tests/test_simple_unit.py` and `tests/test_util.py` (80 passed).
- `mypy --show-error-codes --warn-unused-ignores pyparsing` — clean.
- Added a `CHANGES` entry under *Version 3.3.3 - in development*.