### PR TITLE
Fix as_datetime mis-scaling fractional seconds into microsecond field

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,12 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `pyparsing_common.as_datetime` parse action incorrectly scaling fractional
+  seconds, writing milliseconds into the `datetime` microsecond field (for example
+  "1997-07-16T19:20:30.45" produced microsecond 449 instead of 450000). Fractional
+  seconds are now scaled to microseconds, matching `convert_to_datetime` and the
+  standard library. PR submitted by gaoflow.
+
 - Fixed matching bug in `match_previous_expr()`, when expression is modified with
   `leave_whitespace(recursive=True)`. Issue #633, reported by Ahmed Mohamed Abdelaal,
   PR submitted by fcardosojr18 et AI.

--- a/pyparsing/common.py
+++ b/pyparsing/common.py
@@ -426,7 +426,13 @@ class pyparsing_common:
         second = float(t.second or 0)
         try:
             return datetime(
-                year, month, day, hour, minute, int(second), int((second % 1) * 1000)
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                int(second),
+                round((second % 1) * 1_000_000),
             )
         except ValueError as ve:
             raise ParseException(t, l, f"Invalid date/time: {ve}").with_traceback(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7365,6 +7365,26 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                 "error in parsing valid iso8601_datetime - incorrect value",
             )
 
+        with self.subTest("ppc.as_datetime fractional seconds run_tests"):
+            success, results = (
+                ppc.iso8601_datetime()
+                .add_parse_action(ppc.as_datetime)
+                .run_tests(
+                    """
+                1997-07-16T19:20:30.45
+                """
+                )
+            )
+
+            self.assertTrue(success, "error in parsing valid iso8601_datetime")
+            # as_datetime must scale fractional seconds to microseconds, matching
+            # convert_to_datetime above (0.45 s -> 450000 us, not 449 us).
+            self.assertEqual(
+                datetime.datetime(1997, 7, 16, 19, 20, 30, 450000),
+                results[0][1][0],
+                "error in as_datetime fractional seconds - incorrect microseconds",
+            )
+
         with self.subTest("ppc.uuid success run_tests"):
             success, _ = ppc.uuid.run_tests(
                 """


### PR DESCRIPTION
## Summary

`pyparsing_common.as_datetime` mis-scales fractional seconds: it multiplies the fractional part of the seconds field by `1000` (milliseconds) and floor-truncates it, then stores that value in the `datetime` **microsecond** field.

```python
return datetime(
    year, month, day, hour, minute, int(second), int((second % 1) * 1000)
)
```

So parsing `"1997-07-16T19:20:30.45"` produces `microsecond=449` instead of `450000`:

```python
>>> from pyparsing import pyparsing_common as ppc
>>> ppc.iso8601_datetime().add_parse_action(ppc.as_datetime).parse_string("1997-07-16T19:20:30.45")[0]
datetime.datetime(1997, 7, 16, 19, 20, 30, 449)        # expected ...30, 450000
```

This affects `as_datetime` and the `iso8601_*_validated` expressions built on it. It disagrees with:

- the sibling `convert_to_datetime` parse action (which is already asserted in the test suite to return `microsecond=450000` for the same input), and
- the standard library (`datetime.fromisoformat("1997-07-16T19:20:30.45").microsecond == 450000`).

The `int(...)` floor also drops a microsecond on float-imprecise products (e.g. `0.45 * 1000 == 449.99...` → `449`).

## Fix

Scale the fractional seconds to microseconds and `round()` (which both fixes the unit and removes the floating-point floor error):

```python
round((second % 1) * 1_000_000)
```

A genuine sub-microsecond input degrades through the existing `ValueError` → `ParseException` path, unchanged.

## Verification

- Reproduced on `master` (`057a2e6`); the fix now matches the standard library across `.45`, `.123`, `.5`, `.999999`, `.000001`, and no-fraction inputs.
- Added an `as_datetime` fractional-seconds subtest in `testCommonExpressions`, mirroring the existing `convert_to_datetime` assertion; it fails before the fix (`450000 != 449`) and passes after.
- Full `test_unit.py` / `test_simple_unit.py` suites pass (1841 passed, 6 skipped), unchanged from baseline. `black --fast` leaves the edited region unchanged.
- Added a `CHANGES` entry.

---

This pull request was prepared with the assistance of AI, under my direction and review.
