### PR TITLE
fix: store full non-ParseResults/non-list parse action return as named result

### DIFF
--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -975,13 +975,41 @@ class ParserElement(ABC):
                             raise exc from parse_action_exc
 
                         if tokens is not None and tokens is not ret_tokens:
-                            ret_tokens = ParseResults(
-                                tokens,
-                                self.resultsName,
-                                aslist=self.saveAsList
-                                and isinstance(tokens, (ParseResults, list)),
-                                modal=self.modalResults,
-                            )
+                            if isinstance(tokens, ParseResults):
+                                ret_tokens = ParseResults(
+                                    tokens,
+                                    self.resultsName,
+                                    aslist=self.saveAsList,
+                                    modal=self.modalResults,
+                                )
+                            elif isinstance(tokens, list):
+                                # Lists spread as token list (existing behavior).
+                                ret_tokens = ParseResults(
+                                    tokens,
+                                    self.resultsName,
+                                    aslist=self.saveAsList,
+                                    modal=self.modalResults,
+                                )
+                            else:
+                                # Non-ParseResults, non-list return value:
+                                # wrap so the named result stores the full
+                                # value (fixes issue #401). Null values
+                                # (empty tuple etc.) are not wrapped so
+                                # they clear the result as before.
+                                if isinstance(tokens, tuple) and len(tokens) == 0:
+                                    ret_tokens = ParseResults(
+                                        tokens,
+                                        self.resultsName,
+                                        aslist=False,
+                                        modal=self.modalResults,
+                                    )
+                                else:
+                                    ret_tokens = ParseResults(
+                                        [tokens],
+                                        self.resultsName,
+                                        aslist=False,
+                                        modal=self.modalResults,
+                                    )
                 except Exception as err:
                     # print "Exception raised in user parse action:", err
                     if self.debugActions.debug_fail:
@@ -998,13 +1026,41 @@ class ParserElement(ABC):
                         raise exc from parse_action_exc
 
                     if tokens is not None and tokens is not ret_tokens:
-                        ret_tokens = ParseResults(
-                            tokens,
-                            self.resultsName,
-                            aslist=self.saveAsList
-                            and isinstance(tokens, (ParseResults, list)),
-                            modal=self.modalResults,
-                        )
+                        if isinstance(tokens, ParseResults):
+                            ret_tokens = ParseResults(
+                                tokens,
+                                self.resultsName,
+                                aslist=self.saveAsList,
+                                modal=self.modalResults,
+                            )
+                        elif isinstance(tokens, list):
+                            # Lists spread as token list (existing behavior).
+                            ret_tokens = ParseResults(
+                                tokens,
+                                self.resultsName,
+                                aslist=self.saveAsList,
+                                modal=self.modalResults,
+                            )
+                        else:
+                            # Non-ParseResults, non-list return value:
+                            # wrap so the named result stores the full
+                            # value (fixes issue #401). Null values
+                            # (empty tuple etc.) are not wrapped so
+                            # they clear the result as before.
+                            if isinstance(tokens, tuple) and len(tokens) == 0:
+                                ret_tokens = ParseResults(
+                                    tokens,
+                                    self.resultsName,
+                                    aslist=False,
+                                    modal=self.modalResults,
+                                )
+                            else:
+                                ret_tokens = ParseResults(
+                                    [tokens],
+                                    self.resultsName,
+                                    aslist=False,
+                                    modal=self.modalResults,
+                                )
         if debugging:
             # print("Matched", self, "->", ret_tokens.as_list())
             if self.debugActions.debug_match:

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -975,41 +975,21 @@ class ParserElement(ABC):
                             raise exc from parse_action_exc
 
                         if tokens is not None and tokens is not ret_tokens:
-                            if isinstance(tokens, ParseResults):
+                            if isinstance(tokens, (ParseResults, list)) or tokens == ():
                                 ret_tokens = ParseResults(
                                     tokens,
                                     self.resultsName,
-                                    aslist=self.saveAsList,
-                                    modal=self.modalResults,
-                                )
-                            elif isinstance(tokens, list):
-                                # Lists spread as token list (existing behavior).
-                                ret_tokens = ParseResults(
-                                    tokens,
-                                    self.resultsName,
-                                    aslist=self.saveAsList,
+                                    aslist=self.saveAsList
+                                    and isinstance(tokens, (ParseResults, list)),
                                     modal=self.modalResults,
                                 )
                             else:
-                                # Non-ParseResults, non-list return value:
-                                # wrap so the named result stores the full
-                                # value (fixes issue #401). Null values
-                                # (empty tuple etc.) are not wrapped so
-                                # they clear the result as before.
-                                if isinstance(tokens, tuple) and len(tokens) == 0:
-                                    ret_tokens = ParseResults(
-                                        tokens,
-                                        self.resultsName,
-                                        aslist=False,
-                                        modal=self.modalResults,
-                                    )
-                                else:
-                                    ret_tokens = ParseResults(
-                                        [tokens],
-                                        self.resultsName,
-                                        aslist=False,
-                                        modal=self.modalResults,
-                                    )
+                                ret_tokens = ParseResults(
+                                    [tokens],
+                                    self.resultsName,
+                                    aslist=False,
+                                    modal=self.modalResults,
+                                )
                 except Exception as err:
                     # print "Exception raised in user parse action:", err
                     if self.debugActions.debug_fail:
@@ -1026,41 +1006,21 @@ class ParserElement(ABC):
                         raise exc from parse_action_exc
 
                     if tokens is not None and tokens is not ret_tokens:
-                        if isinstance(tokens, ParseResults):
+                        if isinstance(tokens, (ParseResults, list)) or tokens == ():
                             ret_tokens = ParseResults(
                                 tokens,
                                 self.resultsName,
-                                aslist=self.saveAsList,
-                                modal=self.modalResults,
-                            )
-                        elif isinstance(tokens, list):
-                            # Lists spread as token list (existing behavior).
-                            ret_tokens = ParseResults(
-                                tokens,
-                                self.resultsName,
-                                aslist=self.saveAsList,
+                                aslist=self.saveAsList
+                                and isinstance(tokens, (ParseResults, list)),
                                 modal=self.modalResults,
                             )
                         else:
-                            # Non-ParseResults, non-list return value:
-                            # wrap so the named result stores the full
-                            # value (fixes issue #401). Null values
-                            # (empty tuple etc.) are not wrapped so
-                            # they clear the result as before.
-                            if isinstance(tokens, tuple) and len(tokens) == 0:
-                                ret_tokens = ParseResults(
-                                    tokens,
-                                    self.resultsName,
-                                    aslist=False,
-                                    modal=self.modalResults,
-                                )
-                            else:
-                                ret_tokens = ParseResults(
-                                    [tokens],
-                                    self.resultsName,
-                                    aslist=False,
-                                    modal=self.modalResults,
-                                )
+                            ret_tokens = ParseResults(
+                                [tokens],
+                                self.resultsName,
+                                aslist=False,
+                                modal=self.modalResults,
+                            )
         if debugging:
             # print("Matched", self, "->", ret_tokens.as_list())
             if self.debugActions.debug_match:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3325,6 +3325,43 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             msg=f"Failed accessing named results containing a tuple, got {res.Achar!r}",
         )
 
+    def testParseActionReturningNonListType(self):
+        # from Issue #401
+        for test_value in [
+            (1, 2, 3),
+            {1, 2, 3},
+            {"a": 1},
+            collections.defaultdict(str),
+            "123",
+            0,
+        ]:
+            with self.subTest(f"value = {test_value!r}"):
+                expr = pp.Empty()("name").add_parse_action(lambda: test_value)
+                result = expr.parse_string("")
+                print(result.dump())
+                self.assertParseResultsEquals(
+                    result,
+                    expected_list=[test_value],
+                    expected_dict={"name": test_value},
+                )
+
+    def testParseActionReturningEmptySequence(self):
+        # () and [] are null values, and clear the results name (Issue #401)
+        for test_value in ((), []):
+            with self.subTest(f"value = {test_value!r}"):
+                expr = pp.Empty()("name").add_parse_action(lambda: test_value)
+                result = expr.parse_string("")
+                self.assertNotIn("name", result)
+
+    def testParseActionReturningList(self):
+        # a returned list still spreads into the token list, so the results name
+        # gets its first element - unchanged by #640, see Issue #401
+        expr = pp.Empty()("name").add_parse_action(lambda: [1, 2, 3])
+        result = expr.parse_string("")
+        self.assertParseResultsEquals(
+            result, expected_list=[1, 2, 3], expected_dict={"name": 1}
+        )
+
     def testParserElementAddOperatorWithOtherTypes(self):
         """test the overridden "+" operator with other data types"""
 


### PR DESCRIPTION
When a parse action returns a non-ParseResults, non-list value (e.g. a
tuple, set, or defaultdict), the named result was being set to only the
first element instead of the full return value. This happened because
the value was passed directly to ParseResults(), which indexes into it
with toklist[0] for the named result.

The fix wraps non-list, non-ParseResults values in [tokens] so that
toklist[0] returns the full value. Null values (empty tuple) are not
wrapped because ParseResults._null_values expects them directly. Lists
preserve their existing behavior of spreading as the token list.

Fixes #401.

This pull request was prepared with the assistance of AI, under my
direction and review.