### PR TITLE
fix: ParseResults __add__ and __radd__ arithmetic contract violations

### DIFF
--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -512,6 +512,8 @@ class ParseResults:
             return ""
 
     def __add__(self, other: ParseResults) -> ParseResults:
+        if not isinstance(other, ParseResults):
+            return NotImplemented
         ret = self.copy()
         ret += other
         return ret
@@ -550,9 +552,7 @@ class ParseResults:
         if isinstance(other, int) and other == 0:
             # useful for merging many ParseResults using sum() builtin
             return self.copy()
-        else:
-            # this may raise a TypeError - so be it
-            return other + self
+        return NotImplemented
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self._toklist!r}, {self.as_dict()})"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3761,6 +3761,72 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             result, expected, msg="issue with ParseResults.append()"
         )
 
+    def testParseResultsArithmeticContract(self):
+        """test ParseResults.__add__ and __radd__ arithmetic contract"""
+
+        import operator
+
+        pr = pp.ParseResults(["a", "b"])
+
+        # ParseResults + ParseResults (normal case)
+        pr_sum = pr + pp.ParseResults(["c"])
+        self.assertEqual(["a", "b", "c"], list(pr_sum))
+
+        # ParseResults + non-ParseResults -> TypeError (was AttributeError)
+        with self.assertRaises(
+            TypeError,
+            msg="ParseResults + int should raise TypeError, not AttributeError",
+        ):
+            pr + 1
+
+        with self.assertRaises(
+            TypeError,
+            msg="ParseResults + str should raise TypeError",
+        ):
+            pr + "extra"
+
+        # non-zero int + ParseResults -> TypeError (was RecursionError)
+        with self.assertRaises(
+            TypeError,
+            msg="non-zero int + ParseResults should raise TypeError, not RecursionError",
+        ):
+            1 + pr
+
+        with self.assertRaises(
+            TypeError,
+            msg="float + ParseResults should raise TypeError",
+        ):
+            1.5 + pr
+
+        with self.assertRaises(
+            TypeError,
+            msg="str + ParseResults should raise TypeError",
+        ):
+            "x" + pr
+
+        # 0 + ParseResults works (supports sum() builtin)
+        zero_sum = 0 + pr
+        self.assertEqual(["a", "b"], list(zero_sum))
+
+        # sum() of ParseResults objects works
+        total = sum(
+            [
+                pp.ParseResults(["x"]),
+                pp.ParseResults(["y"]),
+                pp.ParseResults(["z"]),
+            ]
+        )
+        self.assertEqual(["x", "y", "z"], list(total))
+
+        # reduce(operator.add, ...) also works
+        import functools
+
+        reduced = functools.reduce(
+            operator.add,
+            [pp.ParseResults(["m"]), pp.ParseResults(["n"])],
+        )
+        self.assertEqual(["m", "n"], list(reduced))
+
     def testParseResultsClear(self):
         """test simple case of ParseResults.clear()"""
 


### PR DESCRIPTION
## Description

Two related arithmetic contract violations in `ParseResults.__add__` and `__radd__`:

**`__add__` — AttributeError instead of TypeError:** `ParseResults(["a"]) + 1` crashes with `AttributeError` (trying to access `other._tokdict` on an `int`). Per Python's data model, `__add__` should return `NotImplemented` for unrecognized operand types, letting the interpreter raise `TypeError`.

**`__radd__` — RecursionError:** `1 + ParseResults(["a"])` triggers infinite recursion. Python tries `int.__add__(1, ParseResults)` → `NotImplemented` → tries `ParseResults.__radd__(1)` → `return other + self` → `int.__add__(1, ParseResults)` → infinite loop until stack overflow.

**The fix:**
- `__add__`: guard with `isinstance(other, ParseResults)`, return `NotImplemented` otherwise
- `__radd__`: return `NotImplemented` instead of `other + self`

The `0 + ParseResults` special case (support for Python's `sum()` builtin) is preserved.

This pull request was prepared with the assistance of AI, under my direction and review.
