### PR TITLE
fix: deepcopy results names referencing nested ParseResults

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,13 @@ Version 3.3.3 - in development
   location is recorded, while `leave_whitespace()` expressions keep their whitespace.
   Issue #621, reported by MeanSquaredError.
 
+- Fixed `ParseResults.deepcopy()` not deep-copying results names that referenced
+  nested `ParseResults`. Only the token list was copied, so a named token still
+  pointed at the original; changing the original (or the copy) was visible through
+  the other when the token was reached by name, and the same token could differ
+  when reached by index versus by name. Results names now reference the
+  deep-copied tokens. PR submitted by Sarath Francis.
+
 - Update type checking to use `mypy 1.20.0`.
 
 - 5-8% performance boost optimizing `ParseResults.copy()`. Inspired by similar changes

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -683,12 +683,16 @@ class ParseResults:
         .. versionadded:: 3.1.0
         """
         ret = self.copy()
+        # map id() of each copied token to its copy, so that results names
+        # referencing items in the token list stay linked to the copies (and
+        # decoupled from the original)
+        memo: dict[int, Any] = {}
         # replace values with copies if they are of known mutable types
         for i, obj in enumerate(self._toklist):
             if isinstance(obj, ParseResults):
                 ret._toklist[i] = obj.deepcopy()
             elif isinstance(obj, (str, bytes)):
-                pass
+                continue
             elif isinstance(obj, MutableMapping):
                 ret._toklist[i] = dest = type(obj)()
                 for k, v in obj.items():
@@ -697,6 +701,29 @@ class ParseResults:
                 ret._toklist[i] = type(obj)(
                     v.deepcopy() if isinstance(v, ParseResults) else v for v in obj  # type: ignore[call-arg]
                 )
+            else:
+                continue
+            memo[id(obj)] = ret._toklist[i]
+
+        # rebuild the results-name dict so that named results point at the
+        # deep-copied tokens, instead of remaining linked to the original
+        if self._tokdict:
+
+            def copy_value(value):
+                if id(value) in memo:
+                    return memo[id(value)]
+                if isinstance(value, ParseResults):
+                    memo[id(value)] = new_value = value.deepcopy()
+                    return new_value
+                return value
+
+            ret._tokdict = {
+                name: [
+                    _ParseResultsWithOffset(copy_value(value), offset)
+                    for value, offset in occurrences
+                ]
+                for name, occurrences in self._tokdict.items()
+            }
         return ret
 
     def get_name(self) -> str | None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4268,6 +4268,35 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             ],
         )
 
+    def testParseResultsDeepcopy4(self):
+        # a top-level results name pointing at a mutable sub-ParseResults
+        # (the named token is also the list item) must be deep-copied, so the
+        # copy stays decoupled from the original whether reached by index or
+        # by name
+        expr = pp.Group(pp.Word(pp.nums)("a") + pp.Word(pp.nums)("b"))("grp") + pp.Word(
+            pp.alphas
+        )("w")
+        result = expr.parse_string("1 2 xyz")
+
+        r2 = result.deepcopy()
+
+        # named result and list item must be the same object within the copy,
+        # and both must differ from the original
+        self.assertTrue(r2["grp"] is r2[0], "named result diverged from list item")
+        self.assertFalse(
+            r2["grp"] is result["grp"], "deep copy failed for named result"
+        )
+
+        # mutate the original's named sub-result; the deep copy must not change
+        result["grp"][0] = result["grp"]["a"] = "999"
+
+        self.assertParseResultsEquals(
+            r2,
+            expected_list=[["1", "2"], "xyz"],
+            expected_dict={"grp": {"a": "1", "b": "2"}, "w": "xyz"},
+        )
+        self.assertEqual({"a": "1", "b": "2"}, r2["grp"].as_dict())
+
     def testIgnoreString(self):
         """test ParserElement.ignore() passed a string arg"""
 


### PR DESCRIPTION
I ran into this while deep-copying a parse tree so I could edit the copy and leave the original alone. `deepcopy()` copies the token list but leaves the results-name dict pointing at the original tokens, so a named token that is also a list item ends up inconsistent: reaching it by name returns the original object, reaching it by index returns the copy. Mutating either side then leaks through the other by name.

Small repro:

```python
import pyparsing as pp

grp = pp.Group(pp.Word(pp.nums)("a") + pp.Word(pp.nums)("b"))("grp")
r = (grp + pp.Word(pp.alphas)("w")).parse_string("1 2 xyz")
c = r.deepcopy()

c["grp"] is c[0]        # False -> same token, but two different objects in the copy
r["grp"]["a"] = "999"
c.as_dict()             # {'grp': {'a': '999', 'b': '2'}, 'w': 'xyz'}  -> the "deep" copy changed
```

The list item gets deep-copied but the name still resolves to the original, so `c.as_dict()` (which goes through the names) reflects edits made to the original.

The fix rebuilds `_tokdict` in `deepcopy()` so names reference the deep-copied tokens. I keep an id-map of the copied list items so a name that aliases a list item keeps aliasing the same copied object, and a name that doesn't is deep-copied on its own. After the fix `c["grp"] is c[0]` and the copy is fully independent of the original.

Added a test for the named-token case; `pytest tests examples/tiny/tests` and `mypy --show-error-codes --warn-unused-ignores pyparsing` both pass.
