### PR TITLE
Escape control characters in set_debug() debug output

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,12 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed debug output corruption when a parsed line contains a carriage return or
+  other control character. `set_debug()` printed the source line verbatim, so a
+  stray `\r` returned the terminal cursor to column 0 and overwrote the "Match ...
+  at loc" text. Control characters in the debug line are now shown escaped, and the
+  caret stays aligned with the match location. Issue #496, reported by Matthew Rowles.
+
 - Fixed bugs in `ParseResults.__add__()` and `ParseResults.__radd__()`, where
   erroneous `AttributeError` or `RecursionError` could be raised when adding
   `ParseResults` objects to non-`ParseResults` objects, instead of expected

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -354,15 +354,27 @@ def condition_as_parse_action(
     return pa
 
 
+# control characters escaped so they can't corrupt the printed debug line
+# (for example a stray '\r' would otherwise return the cursor to column 0)
+_debug_control_char_map = {c: repr(chr(c))[1:-1] for c in (*range(0x20), 0x7F)}
+
+
 def _default_start_debug_action(
     instring: str, loc: int, expr: ParserElement, cache_hit: bool = False
 ):
     cache_hit_str = "*" if cache_hit else ""
+    current_col = col(loc, instring)
+    current_line = line(loc, instring)
+    escaped_line = current_line.translate(_debug_control_char_map)
+    # keep the caret under the match location after escaping widens the line
+    caret_col = (
+        len(current_line[: current_col - 1].translate(_debug_control_char_map)) + 1
+    )
     print(
         (
-            f"{cache_hit_str}Match {expr} at loc {loc}({lineno(loc, instring)},{col(loc, instring)})\n"
-            f"  {line(loc, instring)}\n"
-            f"  {'^':>{col(loc, instring)}}"
+            f"{cache_hit_str}Match {expr} at loc {loc}({lineno(loc, instring)},{current_col})\n"
+            f"  {escaped_line}\n"
+            f"  {'^':>{caret_col}}"
         )
     )
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9961,6 +9961,42 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             "invalid debug output when using parse action",
         )
 
+    def testSetDebugWithControlCharInLine(self):
+        # issue #496 - a '\r' embedded in the parsed line used to be printed
+        # verbatim, sending the terminal cursor back to column 0 and corrupting
+        # the debug output; control characters should be shown escaped instead
+        with ppt.reset_pyparsing_context():
+            test_stdout = StringIO()
+
+            with resetting(sys, "stdout", "stderr"):
+                sys.stdout = test_stdout
+                sys.stderr = test_stdout
+
+                word = pp.Word(pp.alphas).set_name("word").set_debug()
+                word[...].parse_string("abc\rdef", parse_all=True)
+
+            expected_debug_output = dedent(
+                """\
+                Match word at loc 0(1,1)
+                  abc\\rdef
+                  ^
+                Matched word -> ['abc']
+                Match word at loc 4(1,5)
+                  abc\\rdef
+                       ^
+                Matched word -> ['def']
+                Match word at loc 7(1,8)
+                  abc\\rdef
+                          ^
+                Match word failed, ParseException raised: Expected word, found end of text  (at char 7), (line:1, col:8)
+                """
+            )
+            self.assertEqual(
+                expected_debug_output,
+                test_stdout.getvalue(),
+                "control characters in debug output were not escaped",
+            )
+
     def testEnableDebugWithCachedExpressionsMarkedWithAsterisk(self):
         a = pp.Literal("a").set_name("A").set_debug()
         b = pp.Literal("b").set_name("B").set_debug()


### PR DESCRIPTION
Fixes #496. A `\r` in the parsed line got printed straight into the debug output, so the terminal ran it and the cursor jumped back to column 0, scrambling the "Match ... at loc" text. Parsing was fine, just the debug print.

Now control chars in that line are shown escaped (`\r` prints as `\r`), and the caret is nudged over so it still points at the match.

Your call on one thing: I escape all C0 controls + DEL, not just `\r`, so backspace and stray ANSI escapes can't wreck the output either. Only side effect is a tab now shows as `\t`. Happy to narrow it to `\r` only if you'd rather.

Test in `tests/test_unit.py` parses `"abc\rdef"` and checks the escaped output; fails without the fix.

closes #496