### PR TITLE
Make Word(max=...) match up to max regardless of whitespace in the charset

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,13 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `pyparsing_common.as_datetime` raising `Invalid date/time: microsecond
+  must be in 0..999999` for valid ISO-8601 timestamps whose fractional seconds
+  round up to a full second (e.g. `2021-06-15T12:30:59.9999995`, common in
+  nanosecond-precision timestamps). The rounded microseconds are now added via
+  `timedelta` so the value carries into the next second instead of overflowing
+  the `datetime` microsecond argument. PR submitted by Andrew Chen et AI.
+
 - Fixed debug output corruption when a parsed line contains a carriage return or
   other control character. `set_debug()` printed the source line verbatim, so a
   stray `\r` returned the terminal cursor to column 0 and overwrote the "Match ...

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,11 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `ParseResults.__iadd__` (``+=``) leaking an `AttributeError` about a
+  private attribute when the right-hand operand is not a `ParseResults` (e.g.
+  `results += [1]`). It now returns `NotImplemented` so Python raises a
+  `TypeError`, matching the `__add__` operator. PR submitted by Andrew Chen et AI.
+
 - Fixed `pyparsing_common.as_datetime` raising `Invalid date/time: microsecond
   must be in 0..999999` for valid ISO-8601 timestamps whose fractional seconds
   round up to a full second (e.g. `2021-06-15T12:30:59.9999995`, common in

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,14 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `Word(..., max=n)` raising instead of matching up to `max` characters
+  when the character set contained whitespace. `Word` uses a char-by-char
+  fallback for such sets (instead of the regex fast path), and that fallback
+  raised once the run of matching characters exceeded `max`, so
+  `Word(nums, max=3)` and `Word(nums + " ", max=3)` gave opposite results on
+  the same input. The fallback now matches up to `max` and leaves the rest for
+  the next parser, consistent with the regex path and `testWordMinMaxExactArgs`.
+
 - Fixed debug output corruption when a parsed line contains a carriage return or
   other control character. `set_debug()` printed the source line verbatim, so a
   stray `\r` returned the terminal cursor to column 0 and overwrote the "Match ...

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,14 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `Word(..., max=n)` raising instead of matching up to `max` characters
+  when the character set contained whitespace. `Word` uses a char-by-char
+  fallback for such sets (instead of the regex fast path), and that fallback
+  raised once the run of matching characters exceeded `max`, so
+  `Word(nums, max=3)` and `Word(nums + " ", max=3)` gave opposite results on
+  the same input. The fallback now matches up to `max` and leaves the rest for
+  the next parser, consistent with the regex path and `testWordMinMaxExactArgs`.
+
 - Fixed `QuotedString` stripping whitespace that is part of a multi-character
   quote delimiter, e.g. the leading newline in `QuotedString("\n;",
   multiline=True)`. The delimiter was silently collapsed to `";"`, so the

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,14 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `QuotedString` stripping whitespace that is part of a multi-character
+  quote delimiter, e.g. the leading newline in `QuotedString("\n;",
+  multiline=True)`. The delimiter was silently collapsed to `";"`, so the
+  newline was ignored when matching. `QuotedString` now only rejects
+  quote_char/end_quote_char values that are empty or entirely whitespace, and
+  preserves any surrounding whitespace that is part of a valid delimiter.
+  Reported in issue #492.
+
 - Fixed `pyparsing_common.as_datetime` raising `Invalid date/time: microsecond
   must be in 0..999999` for valid ISO-8601 timestamps whose fractional seconds
   round up to a full second (e.g. `2021-06-15T12:30:59.9999995`, common in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ If you have an example you wish to submit, please follow these guidelines.
   ```
 
 - Submitted examples _must_ be Python 3.9 or later compatible.
-  (It is acceptable if examples use Python features added after 3.6)
+  (It is acceptable if examples use Python features added after 3.9)
 
 - Where possible use operators to create composite parse expressions:
 
@@ -92,18 +92,19 @@ article on the pyparsing wiki, to get a general feel for the historical and futu
 design, and intended developer experience as an embedded DSL.
 
 If you are using new Python features or changing usage of the Python stdlib, please check that they work as
-intended on prior versions of Python (currently back to Python 3.6.8).
+intended on prior versions of Python (currently back to Python 3.9).
 
 ## Some design points
 
-- Minimize additions to the module namespace. Over time, pyparsing's namespace has acquired a _lot_ of names.
+- **Minimize additions to the module namespace**. Over time, pyparsing's namespace has acquired a _lot_ of names.
   New features have been encapsulated into namespace classes to try to hold back the name flooding when importing
   pyparsing.
 
 - New operator overloads for ParserElement will need to show broad applicability, and should be related to
   parser construction.
 
-- Performance tuning should focus on parse time performance. Optimizing parser definition performance is secondary.
+- **Performance tuning should focus on parse time performance**. Optimizing parser definition performance is secondary.
+  (Note that builtin parse actions also run at parse time.)
 
 - New external dependencies will require substantial justification, and if included, will need to be guarded for
   `ImportError`s raised if the external module is not installed.
@@ -133,7 +134,7 @@ These coding styles are encouraged whether submitting code for core pyparsing or
 
 - Maximum line length is 120 characters. (Black will override this.)
 
-- Changes to core pyparsing must be compatible back to Py3.6 without conditionalizing. Later Py3 features may be
+- Changes to core pyparsing must be compatible back to Py3.9 without conditionalizing. Later Py3 features may be
   used in examples by way of illustration.
 
 - `str.format()` statements should use named format arguments (unless this proves to be a slowdown at parse time).
@@ -145,6 +146,9 @@ These coding styles are encouraged whether submitting code for core pyparsing or
 
 - Do not modify `pyparsing_archive.py`. This file is kept as a reference artifact from when pyparsing was distributed
   as a single source file.
+
+- Changes implemented with AI assistance should be annotated in the CHANGES file using "submitted by *author name*
+  et AI". This follows the Latin *et alii* attribution meaning "and others", often abbreviated as "et al."
 
 ## Some documentation points
 

--- a/pyparsing/common.py
+++ b/pyparsing/common.py
@@ -1,7 +1,7 @@
 # common.py
 from .core import *
 from .helpers import DelimitedList, any_open_tag, any_close_tag
-from datetime import datetime
+from datetime import datetime, timedelta
 import sys
 
 PY_310_OR_LATER = sys.version_info >= (3, 10)
@@ -425,14 +425,11 @@ class pyparsing_common:
         minute = int(t.minute or 0)
         second = float(t.second or 0)
         try:
-            return datetime(
-                year,
-                month,
-                day,
-                hour,
-                minute,
-                int(second),
-                round((second % 1) * 1_000_000),
+            # Add the fractional seconds via timedelta so a value that rounds up
+            # to a full second (e.g. "...59.9999995") carries into the next second
+            # instead of overflowing datetime's 0..999999 microsecond argument.
+            return datetime(year, month, day, hour, minute, int(second)) + timedelta(
+                microseconds=round((second % 1) * 1_000_000)
             )
         except ValueError as ve:
             raise ParseException(s, l, f"Invalid date/time: {ve}").with_traceback(

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3365,8 +3365,6 @@ class Word(Token):
         throw_exception = False
         if loc - start < self.minLen:
             throw_exception = True
-        elif self.maxSpecified and loc < instrlen and instring[loc] in body_chars:
-            throw_exception = True
         elif self.asKeyword and (
             (start > 0 and instring[start - 1] in body_chars)
             or (loc < instrlen and instring[loc] in body_chars)

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3715,17 +3715,16 @@ class QuotedString(Token):
         )
         quote_char = quoteChar or quote_char
 
-        # remove white space from quote chars
-        quote_char = quote_char.strip()
-        if not quote_char:
+        # reject empty or whitespace-only quote chars, but preserve any
+        # whitespace that is part of a valid quote delimiter (e.g. a leading
+        # newline in a multiline quote such as "\n;")
+        if not quote_char.strip():
             raise ValueError("quote_char cannot be the empty string")
 
         if end_quote_char is None:
             end_quote_char = quote_char
-        else:
-            end_quote_char = end_quote_char.strip()
-            if not end_quote_char:
-                raise ValueError("end_quote_char cannot be the empty string")
+        elif not end_quote_char.strip():
+            raise ValueError("end_quote_char cannot be the empty string")
 
         self.quote_char: str = quote_char
         self.quote_char_len: int = len(quote_char)

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -519,6 +519,8 @@ class ParseResults:
         return ret
 
     def __iadd__(self, other: ParseResults) -> ParseResults:
+        if not isinstance(other, ParseResults):
+            return NotImplemented
         if not other:
             return self
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7527,6 +7527,24 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             )
 
         with self.subTest(
+            "ppc.as_datetime fractional seconds rounding up carry into next second"
+        ):
+            # A fractional-seconds value that rounds up to a full second (e.g. the
+            # trailing digits of a nanosecond-precision timestamp) must carry into
+            # the next second, not overflow datetime's 0..999999 microsecond arg.
+            parse_dt = ppc.iso8601_datetime().add_parse_action(ppc.as_datetime)
+            self.assertEqual(
+                datetime.datetime(2021, 1, 1, 0, 0, 1),
+                parse_dt.parse_string("2021-01-01T00:00:00.999999999")[0],
+                "as_datetime must carry a rounded-up fractional second, not raise",
+            )
+            self.assertEqual(
+                datetime.datetime(2021, 6, 15, 12, 31, 0),
+                parse_dt.parse_string("2021-06-15T12:30:59.9999995")[0],
+                "as_datetime must carry a rounded-up fractional second across minutes",
+            )
+
+        with self.subTest(
             "ppc.as_datetime ParseException receives input string, not tokens"
         ):
             # as_datetime should raise ParseException with the input string

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3827,6 +3827,24 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         )
         self.assertEqual(["m", "n"], list(reduced))
 
+        # ParseResults += non-ParseResults -> TypeError (was AttributeError),
+        # mirroring the __add__ contract above.
+        pr_iadd = pp.ParseResults(["a", "b"])
+        with self.assertRaises(
+            TypeError,
+            msg="ParseResults += int should raise TypeError, not AttributeError",
+        ):
+            pr_iadd += 1
+        with self.assertRaises(
+            TypeError,
+            msg="ParseResults += list should raise TypeError, not AttributeError",
+        ):
+            pr_iadd += ["extra"]
+
+        # ParseResults += ParseResults still works
+        pr_iadd += pp.ParseResults(["c"])
+        self.assertEqual(["a", "b", "c"], list(pr_iadd))
+
     def testParseResultsClear(self):
         """test simple case of ParseResults.clear()"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5939,6 +5939,23 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                     ["A1234567890"[:exarg]],
                 )
 
+    def testWordMaxIndependentOfWhitespaceInCharset(self):
+        # A Word constructed with an explicit `max` uses an internal regex
+        # fast-path only when its character set contains no space; otherwise
+        # it falls back to the char-by-char parseImpl. Both paths must agree:
+        # `max` means "match at most `max` characters, leaving the remainder"
+        # (see testWordMinMaxExactArgs and the "W:(0-9){1,3}" repr contract).
+        # Regression: the char-by-char path used to raise when the run of body
+        # characters exceeded `max`, so the parse result depended on whether a
+        # space happened to be present in the character set.
+        for extra, path in [("", "regex fast-path"), (" ", "char-by-char path")]:
+            with self.subTest(charset_extra=repr(extra), path=path):
+                expr = pp.Word(pp.nums + extra, max=3)("field") + pp.Word(pp.nums)(
+                    "rest"
+                )
+                result = expr.parse_string("0123456", parse_all=True)
+                self.assertEqual(["012", "3456"], result.as_list())
+
     def testWordMin(self):
         # failing tests
         for min_val in range(3, 5):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2231,6 +2231,32 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         self.assertParseAndCheckList(qs, "*///*", ["/"])
         self.assertParseAndCheckList(qs, "*////*", ["//"])
 
+    def testQuotedStringWithWhitespaceInQuoteChars(self):
+        # Issue #492 - a leading/trailing whitespace character that is part of a
+        # multi-character quote delimiter (such as a newline in "\n;") must not
+        # be stripped away, which previously collapsed the delimiter to ";".
+        with ppt.reset_pyparsing_context():
+            pp.ParserElement.set_default_whitespace_chars("")
+            newline_quote = pp.QuotedString("\n;", multiline=True)
+            self.assertParseAndCheckList(
+                newline_quote, "\n;Hi \n mum!\n;", ["Hi \n mum!"]
+            )
+            self.assertEqual(
+                [["Hi \n mum!"]],
+                newline_quote.search_string("lsjdf \n;Hi \n mum!\n; sldjf").as_list(),
+            )
+            self.assertEqual(
+                [["Hi \n m;um!"]],
+                newline_quote.search_string("lsjdf \n;Hi \n m;um!\n; sldjf").as_list(),
+            )
+
+        # a fully whitespace (or empty) quote_char is still rejected
+        for bad_quote in ("", "   ", "\n"):
+            with self.assertRaises(ValueError):
+                pp.QuotedString(bad_quote)
+            with self.assertRaises(ValueError):
+                pp.QuotedString('"', end_quote_char=bad_quote)
+
     def testRepeater(self):
         if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
             print("skipping this test, not compatible with memoization")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5945,16 +5945,17 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         # it falls back to the char-by-char parseImpl. Both paths must agree:
         # `max` means "match at most `max` characters, leaving the remainder"
         # (see testWordMinMaxExactArgs and the "W:(0-9){1,3}" repr contract).
-        # Regression: the char-by-char path used to raise when the run of body
-        # characters exceeded `max`, so the parse result depended on whether a
-        # space happened to be present in the character set.
         for extra, path in [("", "regex fast-path"), (" ", "char-by-char path")]:
             with self.subTest(charset_extra=repr(extra), path=path):
                 expr = pp.Word(pp.nums + extra, max=3)("field") + pp.Word(pp.nums)(
                     "rest"
                 )
-                result = expr.parse_string("0123456", parse_all=True)
-                self.assertEqual(["012", "3456"], result.as_list())
+                self.assertParseAndCheckDict(
+                    expr,
+                    "0123456",
+                    {"field": "012", "rest": "3456"},
+                    "Failed to parse regex and non-regex parse_impl in Word consistently"
+                )
 
     def testWordMin(self):
         # failing tests

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5983,6 +5983,23 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                     ["A1234567890"[:exarg]],
                 )
 
+    def testWordMaxIndependentOfWhitespaceInCharset(self):
+        # A Word constructed with an explicit `max` uses an internal regex
+        # fast-path only when its character set contains no space; otherwise
+        # it falls back to the char-by-char parseImpl. Both paths must agree:
+        # `max` means "match at most `max` characters, leaving the remainder"
+        # (see testWordMinMaxExactArgs and the "W:(0-9){1,3}" repr contract).
+        # Regression: the char-by-char path used to raise when the run of body
+        # characters exceeded `max`, so the parse result depended on whether a
+        # space happened to be present in the character set.
+        for extra, path in [("", "regex fast-path"), (" ", "char-by-char path")]:
+            with self.subTest(charset_extra=repr(extra), path=path):
+                expr = pp.Word(pp.nums + extra, max=3)("field") + pp.Word(pp.nums)(
+                    "rest"
+                )
+                result = expr.parse_string("0123456", parse_all=True)
+                self.assertEqual(["012", "3456"], result.as_list())
+
     def testWordMin(self):
         # failing tests
         for min_val in range(3, 5):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5989,16 +5989,17 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         # it falls back to the char-by-char parseImpl. Both paths must agree:
         # `max` means "match at most `max` characters, leaving the remainder"
         # (see testWordMinMaxExactArgs and the "W:(0-9){1,3}" repr contract).
-        # Regression: the char-by-char path used to raise when the run of body
-        # characters exceeded `max`, so the parse result depended on whether a
-        # space happened to be present in the character set.
         for extra, path in [("", "regex fast-path"), (" ", "char-by-char path")]:
             with self.subTest(charset_extra=repr(extra), path=path):
                 expr = pp.Word(pp.nums + extra, max=3)("field") + pp.Word(pp.nums)(
                     "rest"
                 )
-                result = expr.parse_string("0123456", parse_all=True)
-                self.assertEqual(["012", "3456"], result.as_list())
+                self.assertParseAndCheckDict(
+                    expr,
+                    "0123456",
+                    {"field": "012", "rest": "3456"},
+                    "Failed to parse regex and non-regex parse_impl in Word consistently"
+                )
 
     def testWordMin(self):
         # failing tests


### PR DESCRIPTION
### The divergence

`Word(..., max=n)` gives opposite results depending on whether the character set happens to contain whitespace:

```python
import pyparsing as pp

pp.Word(pp.nums, max=3).parse_string("0123456")        # ['012']  — matches up to max, leaves the rest
pp.Word(pp.nums + " ", max=3).parse_string("0123456")  # raises ParseException
```

The only difference is a user-invisible internal path choice (`core.py`): a `Word` whose charset has no whitespace uses the regex fast path, which matches up to `max` and leaves the remainder for the next parser; a charset *with* whitespace falls back to the char-by-char `Word.parseImpl`, which instead **raises** once the run of body chars exceeds `max`. So the same public API + same `max` behaves differently based on the charset contents.

The lenient behavior is the one the default (regex) path produces, the one `exact=` already produces in both paths, and the one asserted by the active `tests/test_unit.py::testWordMinMaxExactArgs`. The strict-throw branch in the fallback looks like a leftover: `set(triple_quoted)`-style, it's the one place the two paths disagree on `max`.

### The change

Drop the stale strict-throw branch so the fallback matches the regex path. This breaks zero existing tests; I've added a regression test asserting both charsets yield `["012", "3456"]`, and the full suite passes (1856 passed, 6 skipped).

### Direction is your call

I want to flag honestly that this is a behavior choice, not a clear-cut fix. `CHANGES` for v1.3.1 (2005) documents the **strict** semantics ("`Word(nums, max=3)` ... will raise an exception" on `'0123456'`) as an intentional feature — but that predates the regex fast path and `testWordMinMaxExactArgs`, which encode **lenient**. I went with lenient because it (a) makes the fallback consistent with the path most inputs actually take, (b) matches `exact=`'s existing behavior, and (c) breaks no current tests. The alternative — keep strict and add a bounded-vs-greedy guard to the regex path (plus updating `testWordMinMaxExactArgs`) — is larger and would change currently-passing behavior. Happy to switch to that direction, or close this, if you'd prefer strict.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the divergence, verified it, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
