### PR TITLE
Carry a rounded-up fractional second in as_datetime instead of raising Invalid date/time

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,13 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `pyparsing_common.as_datetime` raising `Invalid date/time: microsecond
+  must be in 0..999999` for valid ISO-8601 timestamps whose fractional seconds
+  round up to a full second (e.g. `2021-06-15T12:30:59.9999995`, common in
+  nanosecond-precision timestamps). The rounded microseconds are now added via
+  `timedelta` so the value carries into the next second instead of overflowing
+  the `datetime` microsecond argument. PR submitted by Andrew Chen et AI.
+
 - Fixed debug output corruption when a parsed line contains a carriage return or
   other control character. `set_debug()` printed the source line verbatim, so a
   stray `\r` returned the terminal cursor to column 0 and overwrote the "Match ...

--- a/pyparsing/common.py
+++ b/pyparsing/common.py
@@ -1,7 +1,7 @@
 # common.py
 from .core import *
 from .helpers import DelimitedList, any_open_tag, any_close_tag
-from datetime import datetime
+from datetime import datetime, timedelta
 import sys
 
 PY_310_OR_LATER = sys.version_info >= (3, 10)
@@ -425,14 +425,11 @@ class pyparsing_common:
         minute = int(t.minute or 0)
         second = float(t.second or 0)
         try:
-            return datetime(
-                year,
-                month,
-                day,
-                hour,
-                minute,
-                int(second),
-                round((second % 1) * 1_000_000),
+            # Add the fractional seconds via timedelta so a value that rounds up
+            # to a full second (e.g. "...59.9999995") carries into the next second
+            # instead of overflowing datetime's 0..999999 microsecond argument.
+            return datetime(year, month, day, hour, minute, int(second)) + timedelta(
+                microseconds=round((second % 1) * 1_000_000)
             )
         except ValueError as ve:
             raise ParseException(s, l, f"Invalid date/time: {ve}").with_traceback(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7527,6 +7527,24 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
             )
 
         with self.subTest(
+            "ppc.as_datetime fractional seconds rounding up carry into next second"
+        ):
+            # A fractional-seconds value that rounds up to a full second (e.g. the
+            # trailing digits of a nanosecond-precision timestamp) must carry into
+            # the next second, not overflow datetime's 0..999999 microsecond arg.
+            parse_dt = ppc.iso8601_datetime().add_parse_action(ppc.as_datetime)
+            self.assertEqual(
+                datetime.datetime(2021, 1, 1, 0, 0, 1),
+                parse_dt.parse_string("2021-01-01T00:00:00.999999999")[0],
+                "as_datetime must carry a rounded-up fractional second, not raise",
+            )
+            self.assertEqual(
+                datetime.datetime(2021, 6, 15, 12, 31, 0),
+                parse_dt.parse_string("2021-06-15T12:30:59.9999995")[0],
+                "as_datetime must carry a rounded-up fractional second across minutes",
+            )
+
+        with self.subTest(
             "ppc.as_datetime ParseException receives input string, not tokens"
         ):
             # as_datetime should raise ParseException with the input string


### PR DESCRIPTION
### Problem

`pyparsing_common.as_datetime` raises `ParseException: Invalid date/time: microsecond must be in 0..999999` for valid ISO-8601 timestamps whose fractional-seconds field rounds up to a full second:

```pycon
>>> from pyparsing import pyparsing_common as ppc
>>> expr = ppc.iso8601_datetime().add_parse_action(ppc.as_datetime)
>>> expr.parse_string("2021-06-15T12:30:59.9999995")
pyparsing.exceptions.ParseException: Invalid date/time: microsecond must be in 0..999999
>>> expr.parse_string("2021-01-01T00:00:00.999999999")
pyparsing.exceptions.ParseException: Invalid date/time: microsecond must be in 0..999999
```

Every input field here is valid — the year/month/day/hour/minute/second are all in range. The `microsecond` that trips the `datetime` constructor is an internally-computed value, so the "Invalid date/time" message points at a field the user never supplied. The `iso8601_datetime` regex accepts arbitrary fractional digits (`\d\d(\.\d*)?`), so sub-microsecond precision (Go `RFC3339Nano`, Kubernetes/Prometheus/systemd logs, DB timestamps) reaches this path in normal use.

### Root cause

`pyparsing/common.py`, in `as_datetime`:

```python
round((second % 1) * 1_000_000),   # can be exactly 1_000_000
```

`round(...)` can produce `1_000_000`, but `datetime`'s microsecond argument must be `0..999999`. This line was added in #639 to fix fractional-second mis-scaling; the `round()` closed the floor error but opened a boundary overflow at fractions ≥ ~0.9999995 s.

### Fix

Add the rounded microseconds via `timedelta`, so a value that rounds up to a full second carries into the next second instead of overflowing:

```python
return datetime(year, month, day, hour, minute, int(second)) + timedelta(
    microseconds=round((second % 1) * 1_000_000)
)
```

### Verification

- Before the fix: `"2021-06-15T12:30:59.9999995"` and `"2021-01-01T00:00:00.999999999"` raise; a new subtest in `testCommonExpressions` fails.
- After the fix: they return `datetime(2021, 6, 15, 12, 31, 0)` and `datetime(2021, 1, 1, 0, 0, 1)`; the subtest passes.
- Unchanged: `0.45 → 450000`, `0.999999 → 999999` (existing assertions still pass), and a literal `"60"` leap second still raises `second must be in 0..59` because `int(second)` is untouched.
- Full `tests/test_unit.py`: 1850 passed, 6 skipped, 0 failed.

The carry (vs. clamping to 999999) matches stdlib `timedelta` rounding; if you'd prefer a different boundary policy, happy to adjust.

---

*Disclosure: this PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*
