### PR TITLE
Guard ParseResults.__iadd__ against non-ParseResults operands

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,11 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `ParseResults.__iadd__` (``+=``) leaking an `AttributeError` about a
+  private attribute when the right-hand operand is not a `ParseResults` (e.g.
+  `results += [1]`). It now returns `NotImplemented` so Python raises a
+  `TypeError`, matching the `__add__` operator. PR submitted by Andrew Chen et AI.
+
 - Fixed `pyparsing_common.as_datetime` raising `Invalid date/time: microsecond
   must be in 0..999999` for valid ISO-8601 timestamps whose fractional seconds
   round up to a full second (e.g. `2021-06-15T12:30:59.9999995`, common in

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -519,6 +519,8 @@ class ParseResults:
         return ret
 
     def __iadd__(self, other: ParseResults) -> ParseResults:
+        if not isinstance(other, ParseResults):
+            return NotImplemented
         if not other:
             return self
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3827,6 +3827,24 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         )
         self.assertEqual(["m", "n"], list(reduced))
 
+        # ParseResults += non-ParseResults -> TypeError (was AttributeError),
+        # mirroring the __add__ contract above.
+        pr_iadd = pp.ParseResults(["a", "b"])
+        with self.assertRaises(
+            TypeError,
+            msg="ParseResults += int should raise TypeError, not AttributeError",
+        ):
+            pr_iadd += 1
+        with self.assertRaises(
+            TypeError,
+            msg="ParseResults += list should raise TypeError, not AttributeError",
+        ):
+            pr_iadd += ["extra"]
+
+        # ParseResults += ParseResults still works
+        pr_iadd += pp.ParseResults(["c"])
+        self.assertEqual(["a", "b", "c"], list(pr_iadd))
+
     def testParseResultsClear(self):
         """test simple case of ParseResults.clear()"""
 


### PR DESCRIPTION
`ParseResults.__add__` returns `NotImplemented` for a non-`ParseResults` operand (added in #642), so `results + [1]` raises a clean `TypeError`. Its in-place twin `__iadd__` was left unguarded, so `results += [1]` instead leaks an internal `AttributeError`:

```python
>>> r = Word(nums)("a").parse_string("1")
>>> r + [9]
TypeError: unsupported operand type(s) for +: 'ParseResults' and 'list'
>>> c = r.copy(); c += [9]
AttributeError: 'list' object has no attribute '_tokdict'
```

This is the `__iadd__` counterpart of #642. The fix mirrors it: return `NotImplemented` for a non-`ParseResults` operand so Python raises `TypeError`. `pr += pr` is unchanged, and the arithmetic-contract test gains `__iadd__` cases.

One behavior note: today `pr += []` / `pr += 0` (a falsy non-`ParseResults`) silently no-ops via the `if not other` short-circuit; with the guard they raise `TypeError` — but that already matches `pr + []`, so it makes `+=` consistent with `+`. This is an error-quality fix (`AttributeError` → `TypeError`), not a changed computation.

---

Disclosure: this PR was authored by an AI coding agent (Claude Code) running on this account — it found the mismatch against #642, reproduced it, wrote the fix and the test, and wrote this description. The human account holder reviews every change and is accountable for it, and the verification above is re-runnable from the diff. Happy to close it if it isn't the kind of contribution you want.
