### PR TITLE
Preserve whitespace in QuotedString multi-char delimiters (fixes #492)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,14 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `QuotedString` stripping whitespace that is part of a multi-character
+  quote delimiter, e.g. the leading newline in `QuotedString("\n;",
+  multiline=True)`. The delimiter was silently collapsed to `";"`, so the
+  newline was ignored when matching. `QuotedString` now only rejects
+  quote_char/end_quote_char values that are empty or entirely whitespace, and
+  preserves any surrounding whitespace that is part of a valid delimiter.
+  Reported in issue #492.
+
 - Fixed `pyparsing_common.as_datetime` raising `Invalid date/time: microsecond
   must be in 0..999999` for valid ISO-8601 timestamps whose fractional seconds
   round up to a full second (e.g. `2021-06-15T12:30:59.9999995`, common in

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -3715,17 +3715,16 @@ class QuotedString(Token):
         )
         quote_char = quoteChar or quote_char
 
-        # remove white space from quote chars
-        quote_char = quote_char.strip()
-        if not quote_char:
+        # reject empty or whitespace-only quote chars, but preserve any
+        # whitespace that is part of a valid quote delimiter (e.g. a leading
+        # newline in a multiline quote such as "\n;")
+        if not quote_char.strip():
             raise ValueError("quote_char cannot be the empty string")
 
         if end_quote_char is None:
             end_quote_char = quote_char
-        else:
-            end_quote_char = end_quote_char.strip()
-            if not end_quote_char:
-                raise ValueError("end_quote_char cannot be the empty string")
+        elif not end_quote_char.strip():
+            raise ValueError("end_quote_char cannot be the empty string")
 
         self.quote_char: str = quote_char
         self.quote_char_len: int = len(quote_char)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2231,6 +2231,32 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         self.assertParseAndCheckList(qs, "*///*", ["/"])
         self.assertParseAndCheckList(qs, "*////*", ["//"])
 
+    def testQuotedStringWithWhitespaceInQuoteChars(self):
+        # Issue #492 - a leading/trailing whitespace character that is part of a
+        # multi-character quote delimiter (such as a newline in "\n;") must not
+        # be stripped away, which previously collapsed the delimiter to ";".
+        with ppt.reset_pyparsing_context():
+            pp.ParserElement.set_default_whitespace_chars("")
+            newline_quote = pp.QuotedString("\n;", multiline=True)
+            self.assertParseAndCheckList(
+                newline_quote, "\n;Hi \n mum!\n;", ["Hi \n mum!"]
+            )
+            self.assertEqual(
+                [["Hi \n mum!"]],
+                newline_quote.search_string("lsjdf \n;Hi \n mum!\n; sldjf").as_list(),
+            )
+            self.assertEqual(
+                [["Hi \n m;um!"]],
+                newline_quote.search_string("lsjdf \n;Hi \n m;um!\n; sldjf").as_list(),
+            )
+
+        # a fully whitespace (or empty) quote_char is still rejected
+        for bad_quote in ("", "   ", "\n"):
+            with self.assertRaises(ValueError):
+                pp.QuotedString(bad_quote)
+            with self.assertRaises(ValueError):
+                pp.QuotedString('"', end_quote_char=bad_quote)
+
     def testRepeater(self):
         if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
             print("skipping this test, not compatible with memoization")


### PR DESCRIPTION
Fixes #492

## Root cause
`QuotedString.__init__` normalized the delimiters with `quote_char.strip()` and `end_quote_char.strip()` before building the match pattern. `strip()` was intended to reject empty / whitespace-only delimiters, but it also removed whitespace that is a legitimate part of a multi-character delimiter.

For example, `QuotedString("
;", multiline=True)` had its `quote_char` silently reduced to `";"`. The generated pattern became `;(?:(?:[^;]))*;`, so the leading newline was ignored and matches started/ended at the wrong positions:

```python
ParserElement.set_default_whitespace_chars("")
nq = QuotedString("
;", multiline=True)
nq.search_string("lsjdf 
;Hi 
 mum!
; sldjf")   # got [['Hi 
 mum!
']], expected [['Hi 
 mum!']]
nq.search_string("lsjdf 
;Hi 
 m;um!
; sldjf")  # got [['Hi 
 m']],       expected [['Hi 
 m;um!']]
```

## Fix
Validate with `not quote_char.strip()` (and the same for `end_quote_char`) so empty or all-whitespace delimiters are still rejected, but keep the original, unstripped value so whitespace that is part of a valid delimiter is preserved.

## Tests
Added `testQuotedStringWithWhitespaceInQuoteChars` covering the reported cases and confirming empty / all-whitespace quote chars still raise `ValueError`. Added a CHANGES entry.

Full core suite green:
```
1936 passed, 6 skipped, 2021 subtests passed
```
