### PR TITLE
perf: stop rebuilding a results-name occurrence list on every append

### DIFF
--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -86,6 +86,7 @@ class ParseResults:
     _modal: bool
     _toklist: list[Any]
     _tokdict: dict[str, Any]
+    _own_keys: set[Any] | None
 
     __slots__ = (
         "_name",
@@ -94,6 +95,7 @@ class ParseResults:
         "_modal",
         "_toklist",
         "_tokdict",
+        "_own_keys",
     )
 
     class List(list):
@@ -186,6 +188,7 @@ class ParseResults:
         else:
             self._toklist = [toklist]
         self._tokdict = {}
+        self._own_keys = None
         return self
 
     # Performance tuning: we construct a *lot* of these, so keep this
@@ -249,22 +252,43 @@ class ParseResults:
 
     def __setitem__(self, k, v, isinstance=isinstance):
         if isinstance(v, _ParseResultsWithOffset):
-            self._tokdict[k] = self._tokdict.get(k, list()) + [v]
+            self._append_occurrence(k, v)
             sub = v.result
         elif isinstance(k, (int, slice)):
             self._toklist[k] = v
             sub = v
         else:
-            self._tokdict[k] = self._tokdict.get(k, []) + [
-                _ParseResultsWithOffset(v, 0)
-            ]
+            self._append_occurrence(k, _ParseResultsWithOffset(v, 0))
             sub = v
         if isinstance(sub, ParseResults):
             sub._parent = self
 
+    def _append_occurrence(self, k, v) -> None:
+        # Recording an occurrence of results name k used to rebuild that whole
+        # list (``tokdict[k] = tokdict.get(k, []) + [v]``), so accumulating n
+        # occurrences of a single name cost O(n**2). Append in place instead,
+        # but only for a name in _own_keys: one whose list this ParseResults
+        # built itself and has not since shared with a copy() or removed. Any
+        # other name evaluates the original expression unchanged, so its
+        # behavior - including the TypeError raised when _tokdict[k] holds a
+        # non-list - is preserved, and the list is stored back either way, so
+        # the number of key lookups (hence of hash/eq calls) is unchanged too.
+        tokdict = self._tokdict
+        own_keys = self._own_keys
+        if type(own_keys) is set and k in own_keys:
+            tokdict[k].append(v)
+            return
+        tokdict[k] = tokdict.get(k, []) + [v]
+        if type(own_keys) is set:
+            own_keys.add(k)
+        elif own_keys is None:
+            self._own_keys = {k}
+
     def __delitem__(self, i):
         if not isinstance(i, (int, slice)):
             del self._tokdict[i]
+            if self._own_keys is not None:
+                self._own_keys.discard(i)
             return
 
         # slight optimization if del results[:]
@@ -502,6 +526,7 @@ class ParseResults:
         """
         del self._toklist[:]
         self._tokdict.clear()
+        self._own_keys = None
 
     def __getattr__(self, name):
         try:
@@ -670,6 +695,12 @@ class ParseResults:
         ret: ParseResults = object.__new__(ParseResults)
         ret._toklist = self._toklist[:]
         ret._tokdict = {**self._tokdict}
+        # ret's occurrence lists are the very same list objects as self's, so
+        # neither side may extend one in place any more: both drop their record
+        # of which lists are private (see _append_occurrence). Sharing the
+        # lists here is what keeps copy() O(number of results names) rather
+        # than O(number of occurrences).
+        ret._own_keys = self._own_keys = None
         ret._parent = self._parent
         ret._all_names = {*self._all_names}
         ret._name = self._name
@@ -714,6 +745,7 @@ class ParseResults:
             ]
             for name, occurrences in self._tokdict.items()
         }
+        ret._own_keys = None
 
         return ret
 
@@ -881,6 +913,11 @@ class ParseResults:
 
     # add support for pickle protocol
     def __getstate__(self):
+        # The dict copy is shallow, so the state shares this instance's occurrence
+        # lists. Give up ownership of them: appending in place would otherwise also
+        # append to whatever is rebuilt from this state. `copy.copy` reaches here,
+        # since there is no __copy__ or __reduce__.
+        self._own_keys = None
         return (
             self._toklist,
             (
@@ -895,6 +932,9 @@ class ParseResults:
         self._toklist, (self._tokdict, par, inAccumNames, self._name) = state
         self._all_names = set(inAccumNames)
         self._parent = None
+        # _tokdict came from outside this instance (unpickling, or copy.copy(),
+        # which reuses the source object's occurrence lists) - own none of it.
+        self._own_keys = None
 
     def __getnewargs__(self):
         return self._toklist, self._name


### PR DESCRIPTION
Setting a results name that already exists appends to its occurrence list by rebuilding the whole list, so producing n occurrences of one name costs O(n^2). A grammar using a `name*` list-collector over a long input pays this directly.

This appends in place instead, guarded by a small `_own_keys` set recording which names' lists the instance is sole owner of. Every path that shares a list hands ownership back, so an in-place append can never reach another instance's list.

## Numbers

`time.process_time`, alternating base and patched subprocesses, min of 2 runs, appending n occurrences of one results name:

| n    | master    | this branch | speedup | master growth | branch growth |
|-----:|----------:|------------:|--------:|--------------:|--------------:|
| 1000 |   1.10 ms |     0.53 ms |    2.1x |             - |             - |
| 2000 |   3.97 ms |     0.74 ms |    5.3x |         x3.60 |         x1.40 |
| 4000 |  19.89 ms |     1.57 ms |   12.6x |         x5.01 |         x2.12 |
| 8000 |  86.34 ms |     3.15 ms |   27.4x |         x4.34 |         x2.00 |

`master` grows roughly 4.3x per doubling against this branch's 2x, so the quadratic term is gone.

This is narrow, and it is a trade rather than a free win. It only helps a results name that accumulates many occurrences, and it costs a little on the common case.

An ordinary parse making a single named assignment is about 6 percent slower. Median of 6 alternating runs of 30,000 parses of `Word(alphas)("w")`:

```
master:      59.66 ms
this branch: 63.19 ms   (0.944x)
```

That is the cost of maintaining the `_own_keys` ownership set on a path that never benefits from it, since a name with one occurrence has nothing to amortise.

So: roughly 6 percent on single-occurrence names, in exchange for removing the quadratic on names that accumulate many, where it is 27x at n=8000 and still growing. Whether that trade is worth taking is your call, and I would understand closing this if the common case matters more.

If you would prefer, I am happy to try a version that only starts tracking ownership once a name reaches a second occurrence, which should leave the single-assignment path untouched. I did not want to push a redesign without asking first.

## Behaviour

The ownership set is cleared in `copy()`, `__delitem__`, `clear()`, `__setstate__`, `__deepcopy__` and `__getstate__`.

`__getstate__` is the one that matters and it was missing in my first draft. `ParseResults` defines no `__copy__` and no `__reduce__`, so `copy.copy` routes through `__getstate__` then `__setstate__`, and `__getstate__` returns `self._tokdict.copy()`, which is shallow. Without clearing ownership there, the source keeps handing out lists the copy now shares, and appending to the source also grew the copy:

```python
r = grammar.parse_string("abc")
c = copy.copy(r)
for i in range(4):
    r["w"] = "src%d" % i

# master:  c["w"] == 'abc',  len 1
# unfixed: c["w"] == 'src3', len 5
```

Differential testing against `master`: 45 comparisons over 5 grammars, crossing parse, repeated append, `copy.copy`, `copy.deepcopy`, pickle round-trip, `ParseResults.copy()`, append-to-source-after-copy, and `del`, comparing `as_list`, `as_dict` and `dump` output. 0 mismatches.

## Checks

`pytest` gives 2056 passed, 27 skipped, exit code 0, matching `master` exactly. The tox `mypy-check` gate passes with no issues in 17 source files.

`black --check` reports a diff on `pyparsing/results.py`, but the pristine file fails identically (it wants a blank line removed after the `.util` import), so that is pre-existing rather than introduced here, and `black` is not in the tox envlist.
