### PR TITLE
Assert keyword chars instead of \b in one_of(as_keyword=True) regex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,14 @@ Version 3.3.3 - in development
 ------------------------------
 - Adding support for Python 3.15.
 
+- Fixed `one_of(..., as_keyword=True)` never matching symbols that begin or end
+  with a non-word character, such as `one_of("< > <= >=", as_keyword=True)`. The
+  generated regex wrapped the alternation in `\b`, which asserts a *word*
+  character on the outside; it now asserts the absence of a keyword character,
+  which is what `Keyword` checks, and so also follows
+  `Keyword.set_default_keyword_chars()`. Reported in issue #554 by theroucken.
+  Submitted by Haïm Dimerman et AI.
+
 - Fixed `Word(..., max=n)` raising instead of matching up to `max` characters
   when the character set contained whitespace. `Word` uses a char-by-char
   fallback for such sets (instead of the regex fast path), and that fallback

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -9,6 +9,7 @@ from . import __diag__
 from .core import *
 from .util import (
     _bslash,
+    _collapse_string_to_ranges,
     _flatten,
     _escape_regex_range_chars,
     make_compressed_re,
@@ -188,10 +189,10 @@ def one_of(
     :param strs: a string of space-delimited literals, or a collection of
        string literals
     :param caseless: treat all literals as caseless
-    :param use_regex: bool - as an optimization, will
-       generate a :class:`Regex` object; otherwise, will generate
-       a :class:`MatchFirst` object (if ``caseless=True`` or
-       ``as_keyword=True``, or if creating a :class:`Regex` raises an exception)
+    :param use_regex: bool - as an optimization, will generate a :class:`Regex`
+       object, even if ``caseless=True`` or ``as_keyword=True``; otherwise, or
+       if creating a :class:`Regex` raises an exception, will generate a
+       :class:`MatchFirst` object
     :param as_keyword: bool - enforce :class:`Keyword`-style matching on the
        generated expressions
 
@@ -277,9 +278,11 @@ def one_of(
             else:
                 patt = "|".join(re.escape(sym) for sym in symbols)
 
-            # wrap with \b word break markers if defining as keywords
-            if asKeyword:
-                patt = rf"\b(?:{patt})\b"
+            # assert keyword boundaries if defining as keywords; \b is wrong here,
+            # since it asserts a word character outside a symbol like "<=" or "+case1"
+            if asKeyword and Keyword.DEFAULT_KEYWORD_CHARS:
+                kwd_chars = _collapse_string_to_ranges(Keyword.DEFAULT_KEYWORD_CHARS)
+                patt = rf"(?<![{kwd_chars}])(?:{patt})(?![{kwd_chars}])"
 
             ret = Regex(patt, flags=re_flags)
             ret.set_name(" | ".join(repr(s) for s in symbols))

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9624,6 +9624,55 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
         )
         self.assertTrue(success, "failed keyword one_of failure tests")
 
+    def testOneOfKeywordsWithNonKeywordCharacters(self):
+        # one_of(..., as_keyword=True) builds a Regex for speed, but must match
+        # the same text at the same locations as the equivalent Keyword
+        # expressions - including symbols that begin or end with a non-keyword
+        # character (Issue #554), and "$", which is a keyword character but not
+        # a regex word character.
+        tests = [
+            (["+case1", "+case2"], {"caseless": True}, "+case2"),
+            (["+case1", "+case2"], {"caseless": True}, "x+case1"),
+            (["<", "<=", ">="], {}, "a <= b < c"),
+            (["<", "<="], {}, "<=<"),
+            (["if", "else"], {}, "$if x"),
+            (["if", "else"], {}, "if$ x"),
+            (["a", "b"], {"caseless": True}, "A b ab"),
+        ]
+
+        def scan(expr, test_string):
+            return [(t.as_list(), s, e) for t, s, e in expr.scan_string(test_string)]
+
+        for symbols, kwargs, test_string in tests:
+            with self.subTest(symbols=symbols, kwargs=kwargs, string=test_string):
+                as_regex = pp.one_of(symbols, as_keyword=True, **kwargs)
+                as_keywords = pp.one_of(
+                    symbols, as_keyword=True, use_regex=False, **kwargs
+                )
+                self.assertEqual(
+                    scan(as_keywords, test_string),
+                    scan(as_regex, test_string),
+                    f"one_of({symbols}, as_keyword=True, {kwargs}) did not match"
+                    f" the equivalent Keyword expressions in {test_string!r}",
+                )
+
+        # the generated regex must also follow a redefined keyword character set,
+        # including an empty one (meaning no character is a keyword character)
+        for keyword_chars in ("<>=", ""):
+            with self.subTest(keyword_chars=keyword_chars):
+                with ppt.reset_pyparsing_context():
+                    pp.Keyword.set_default_keyword_chars(keyword_chars)
+                    symbols = ["<=", ">="]
+                    self.assertEqual(
+                        scan(
+                            pp.one_of(symbols, as_keyword=True, use_regex=False),
+                            "a<=b >= c",
+                        ),
+                        scan(pp.one_of(symbols, as_keyword=True), "a<=b >= c"),
+                        f"one_of(as_keyword=True) did not honor keyword chars"
+                        f" {keyword_chars!r}",
+                    )
+
     def testWarnUngroupedNamedTokens(self):
         """
         - warn_ungrouped_named_tokens_in_collection - flag to enable warnings when a results


### PR DESCRIPTION
Fixes #554.

`one_of(..., as_keyword=True)` never matches a symbol that begins or ends with a non-word character:

```python
import pyparsing as pp

pp.one_of("< > <= >=", as_keyword=True).parse_string("<= 1")
# ParseException: Expected '<=' | '>=' | '<' | '>', found '<'  (at char 0)

pp.one_of("< > <= >=", as_keyword=True, use_regex=False).parse_string("<= 1")
# ['<=']
```

Since 3.0.2 `one_of` always builds a `Regex`, and that path wraps the alternation in `\b`. `\b` asserts a *word* character on the outside, which is the opposite of what is wanted next to a symbol, so `\b(?:<=|>=)\b` can never match at the start of `"<= 1"`. It also goes the other way: `$` is in `Keyword.DEFAULT_KEYWORD_CHARS` but is not a regex word character, so `one_of("if", as_keyword=True)` matches the `if` in `"$if x"` where `Keyword("if")` refuses it.

The fix asserts what `Keyword.parseImpl` actually checks - no keyword character immediately before or after the match - so the `use_regex=True` and `use_regex=False` forms agree again:

```
\b(?:<=|>=)\b   ->   (?<![$0-9A-Z_a-z])(?:<=|>=)(?![$0-9A-Z_a-z])
```

The class is derived from `Keyword.DEFAULT_KEYWORD_CHARS` rather than hardcoded, so the regex now follows `set_default_keyword_chars()` too (it previously ignored it). Empty keyword chars skips the assertions entirely, since `[]` would silently swallow the rest of the pattern rather than raise.

Behavior changes worth calling out, both in the direction of matching `Keyword`:

- symbols adjacent to `$` (and any custom keyword chars) are now rejected where `\b` accepted them
- one gap remains: under `caseless=True` the regex runs with `IGNORECASE`, which case-folds `İ` (U+0130) and `K` (U+212A) into `[A-Za-z]`, while `Keyword` compares `.upper()` against ASCII. Those two code points are treated as keyword characters by the regex path and not by `Keyword`. Closing that would mean enumerating the code points whose `.upper()` lands in the ASCII set; it did not seem worth it, but say the word if you would rather have it.

I checked this with a differential fuzzer comparing the regex form against `use_regex=False` over random symbol sets and inputs (regex metacharacters, whitespace, mixed case, single-character sets, non-ASCII): 3135 mismatches out of 60000 before, 0 after. The new test is the same differential, comparing `scan_string` output so match positions are pinned and not just the tokens.

The `use_regex` docstring hunk is a drive-by: it has described the pre-3.0.2 behavior since 3.0.2. Happy to drop it if you would rather take that separately.

Two things I deliberately left out: `Word.__init__` builds `rf"\b{self.reString}\b"` for its own `as_keyword` and has the same bug (`pp.Word("+abc", as_keyword=True).search_string("+ab")` gives `['ab']`, dropping the `+`), but it is a separate class with its own test surface. And the caseless `symbol_map[t[0].lower()]` parse action raises `KeyError` for symbols whose case does not round-trip, which happens with `as_keyword=False` too. Both look like separate issues; let me know if you want either folded in.

`pytest tests examples/tiny/tests` passes (2070 passed, 27 skipped), as do `mypy --warn-unused-ignores pyparsing` and `sphinx-build -b doctest docs`. `black` leaves `helpers.py` unchanged; its one complaint in `tests/test_unit.py` is pre-existing in `Test08_WithUnboundedPackrat` and I left it alone.

---
Used AI assistance on this; I reviewed and tested the change myself.