### PR TITLE
Fix match_previous_expr to match nested and repeated expressions (issue #560)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -94,6 +94,14 @@ Version 3.3.3 - in development
   `leave_whitespace(recursive=True)`. Issue #633, reported by Ahmed Mohamed Abdelaal,
   PR submitted by fcardosojr18 et AI.
 
+- Fixed `match_previous_expr()` failing to match nested or repeated expressions, so that
+  it can now be used for matching nested open/close tags. A new guard parse action was
+  added on every match of the repeated expression and never removed, so all of them ran
+  on each attempt to match and only one could succeed; a second pair anywhere in the
+  input would fail, and after a failed parse the expression would keep rejecting valid
+  input. The pending matches are now kept on a stack, so an inner match pairs with the
+  nearest enclosing one. Issue #560, PR submitted by Rajesh Kanade et AI.
+
 - Fixed `Located` reporting a `locn_start` that included leading whitespace when the
   wrapped expression delegates whitespace skipping to sub-expressions (such as
   `MatchFirst` or `And`). The leading whitespace is now skipped before the start

--- a/pyparsing/helpers.py
+++ b/pyparsing/helpers.py
@@ -151,23 +151,57 @@ def match_previous_expr(expr: ParserElement) -> ParserElement:
     in ``"1:10"``; the expressions are evaluated first, and then
     compared, so ``"1"`` is compared with ``"10"``. Do *not* use
     with packrat parsing enabled.
+
+    Matches may be nested, so that an inner match is paired with the
+    nearest enclosing occurrence of ``expr``:
+
+    .. testcode::
+
+       tag_name = Word(alphas)
+       open_tag = "<" + tag_name + ">"
+       close_tag = "</" + match_previous_expr(tag_name) + ">"
+
+    will match ``"<a><b></b></a>"``, but not ``"<a><b></a></b>"``.
     """
     rep = Forward()
     e2 = expr.copy()
     rep <<= e2
 
+    # stack of (location, tokens) for matches of expr not yet paired with a
+    # match of rep, innermost last
+    match_stack: list[tuple[int, list]] = []
+    last_match: typing.Optional[tuple[int, list]] = None
+
     def copy_token_to_repeater(s, l, t):
-        match_tokens = _flatten(t.as_list())
+        nonlocal last_match
 
-        def must_match_these_tokens(s, l, t):
-            these_tokens = _flatten(t.as_list())
-            if these_tokens != match_tokens:
-                raise ParseException(
-                    s, l, f"Expected {match_tokens}, found{these_tokens}"
-                )
+        # entries at or after this location belong to a branch that was
+        # abandoned on backtracking, and can never be paired
+        while match_stack and match_stack[-1][0] >= l:
+            match_stack.pop()
+        match_stack.append((l, _flatten(t.as_list())))
+        last_match = None
 
-        e2.add_parse_action(must_match_these_tokens, call_during_try=True)
+    def must_match_these_tokens(s, l, t):
+        nonlocal last_match
 
+        these_tokens = _flatten(t.as_list())
+
+        # a memoizing parser may run this action more than once for the
+        # same match, which must not consume a second stack entry
+        if last_match == (l, these_tokens):
+            return
+
+        if not match_stack:
+            raise ParseException(s, l, "no previous expression to match")
+
+        match_tokens = match_stack[-1][1]
+        if these_tokens != match_tokens:
+            raise ParseException(s, l, f"Expected {match_tokens}, found{these_tokens}")
+        match_stack.pop()
+        last_match = (l, these_tokens)
+
+    e2.add_parse_action(must_match_these_tokens, call_during_try=True)
     expr.add_parse_action(copy_token_to_repeater, call_during_try=True)
     rep.set_name(f"(prev) {expr}")
     return rep

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2559,6 +2559,71 @@ class Test02_WithoutPackrat(ppt.TestParseResultsAsserts, TestCase):
                 ):
                     expr.parse_string(tst)
 
+    def testRepeaterNested(self):
+        """test match_previous_expr with nested and repeated matches"""
+
+        if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
+            print("skipping this test, not compatible with memoization")
+            return
+
+        LBRACE, RBRACE, SLASH = map(pp.Suppress, "{}/")
+        tag_name = pp.Word(pp.alphanums + "_")
+        open_tag = LBRACE + tag_name + RBRACE
+        close_tag = LBRACE + SLASH + pp.match_previous_expr(tag_name) + RBRACE
+
+        content = pp.Forward()
+        content <<= (open_tag + pp.Group(content) + close_tag) | pp.Word(pp.alphas)
+
+        tests = [
+            ("{a}xx{/a}", True),
+            ("{a}{b}xx{/b}{/a}", True),
+            ("{a}{b}{c}xx{/c}{/b}{/a}", True),
+            ("{a}{b}xx{/a}{/b}", False),
+            ("{a}{b}xx{/b}{/c}", False),
+            ("{a}xx{/b}", False),
+        ]
+
+        for tst, expected in tests:
+            if expected:
+                content.parse_string(tst, parse_all=True)
+            else:
+                with self.assertRaisesParseException(
+                    msg=f"Failed nested repeater test, expected fail: {tst=}"
+                ):
+                    content.parse_string(tst, parse_all=True)
+
+    def testRepeaterReusedParser(self):
+        """test match_previous_expr matches repeatedly, and after a failed parse"""
+
+        if ParserElement._packratEnabled or ParserElement._left_recursion_enabled:
+            print("skipping this test, not compatible with memoization")
+            return
+
+        first = pp.Word(pp.alphas)
+        second = pp.match_previous_expr(first)
+        expr = first + pp.Suppress(":") + second
+
+        # repeated matches within a single parse
+        self.assertParseAndCheckList(
+            pp.OneOrMore(expr), "a:a b:b c:c", ["a", "a", "b", "b", "c", "c"]
+        )
+
+        # a mismatch must not poison later parses of the same expression
+        tests = [("d:d", True), ("e:f", False), ("g:g", True)]
+        for tst, expected in tests:
+            if expected:
+                self.assertParseAndCheckList(
+                    expr,
+                    tst,
+                    tst.split(":"),
+                    msg=f"Failed reused repeater test, expected pass: {tst=}",
+                )
+            else:
+                with self.assertRaisesParseException(
+                    msg=f"Failed reused repeater test, expected fail: {tst=}"
+                ):
+                    expr.parse_string(tst, parse_all=True)
+
     def testSetNameToStrAndNone(self):
         wd = pp.Word(pp.alphas)
         with self.subTest():


### PR DESCRIPTION
Fixes #560.

### Cause

`copy_token_to_repeater` adds a new `must_match_these_tokens` guard to the repeated expression on
every match of the leading expression, and never removes one. After N matches the expression carries
N guards, each closed over a different set of tokens, and all of them run on every attempt to match
the repeat — so at most one can succeed.

That breaks more than nesting:

| input | expected | before |
|---|---|---|
| `{a}xx{/a}` | match | match |
| `{a}{b}xx{/b}{/a}` | match | fails |
| two sequential pairs, `a:a b:b` under `OneOrMore` | match | fails |
| reparsing valid input after one failed parse | match | fails |

The guard list also grows without bound for the lifetime of the expression.

### Change

Keep the pending matches on a stack of `(location, tokens)` and register the guard once at
construction, so an inner match pairs with the nearest enclosing one. Entries recorded at or after
the current location are dropped on the way in, so matches left behind by a branch that was
backtracked out of can never be paired — that keeps the stack bounded (it returns to empty after
every parse; measured at 2000 sequential pairs and at 200 levels of nesting).

A memoizing parser can run the guard twice for the same match, so the guard returns early if it is
re-entered for the location and tokens it just matched. Without that, `match_previous_expr` under
`enable_left_recursion()` regressed relative to master.

The `ParseException` message is unchanged, byte for byte, in case anyone matches on it.

### Tests

Two tests added next to the existing `testRepeater*` tests, both failing before this change and
passing after:

- `testRepeaterNested` — three nesting depths, plus crossed and mismatched close tags that must
  still be rejected.
- `testRepeaterReusedParser` — repeated matches in one parse, and that a mismatch does not stop the
  same expression from matching valid input afterwards.

Full suite: 2097 passed before, 2109 after (the 12 are the two new tests across the test classes),
27 skipped either way. `mypy --show-error-codes --warn-unused-ignores pyparsing` is clean and the
change is black-clean.

Checked against `enable_packrat()` and `enable_left_recursion()` as well: both fix the repeat case
and neither regresses against master. Also checked `scan_string`/`search_string`, lookahead contexts
(`NotAny`, `FollowedBy`, `Opt`), and two independent `match_previous_expr` instances in one grammar.

